### PR TITLE
fix ESM wasm build

### DIFF
--- a/modules/wasm.py
+++ b/modules/wasm.py
@@ -658,8 +658,6 @@ def run_task_generate():
             # Generate UMD (CommonJS + AMD) module and .wasm file
             umd_command = [
                 *base_command,
-                "-s",
-                "WASM=1",
                 "-o",
                 os.path.join(gen_out_dir, "pdfium.js"),
  
@@ -670,8 +668,6 @@ def run_task_generate():
             l.colored("Compiling ES6 module with emscripten...", l.YELLOW)
             es6_command = [
                 *base_command,
-                "-s",
-                "WASM=0",
                 "-s"
                 "EXPORT_ES6=1",
                 "-o",


### PR DESCRIPTION
I made a mistake in the ES WebAssembly build by using the flag -sWASM=0. I initially thought this flag would simply prevent the generation of a WebAssembly binary, but I was wrong. Instead, it embedded everything into a large JavaScript file using wasm2js. In this PR, I removed that flag, and now it generates two WebAssembly files:

```
drwxr-xr-x  7 hyzyla  staff      224 Aug 31 13:11 .
drwxr-xr-x  6 hyzyla  staff      192 Aug 31 13:11 ..
-rw-r--r--  1 hyzyla  staff    46380 Aug 31 13:11 index.html
-rw-r--r--  1 hyzyla  staff   159408 Aug 31 13:11 pdfium.esm.js
-rwxr-xr-x  1 hyzyla  staff  3899985 Aug 31 13:11 pdfium.esm.wasm
-rw-r--r--  1 hyzyla  staff   159451 Aug 31 13:11 pdfium.js
-rwxr-xr-x  1 hyzyla  staff  3899985 Aug 31 13:11 pdfium.wasm
```

Both `pdfium.wasm` and `pdfium.esm.wasm` are identical, but the `pdfium.esm.js` module links to `pdfium.esm.wasm`, and `pdfium.js` links to `pdfium.wasm`. I'm not sure if it's currently possible to configure `em++` to point to the same file for both, but I think this solution is acceptable for now.