### PR TITLE
Add minimal package.json to support `npm install`

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -107,6 +107,12 @@ jobs:
           name: artifact-${{ matrix.config.target }}
           path: ${{ matrix.config.target }}.tgz
 
+      - name: Save per-config package (release)
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact-${{ matrix.config.target }}-release
+          path: ${{ matrix.config.target }}-release.tgz
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
@@ -117,6 +123,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: artifact-wasm
+      - name: Load per-config package (release)
+        uses: actions/download-artifact@v4
+        with:
+          name: artifact-wasm-release
       - name: Get release
         id: get_release
         uses: bruceadams/get-release@v1.2.2
@@ -131,4 +141,13 @@ jobs:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: wasm.tgz
           asset_name: wasm.tgz
+          asset_content_type: application/tar+gzip
+      - name: Upload per-config package (release)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: wasm-release.tgz
+          asset_name: wasm-release.tgz
           asset_content_type: application/tar+gzip

--- a/extras/wasm/template/package.json
+++ b/extras/wasm/template/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "pdfium-lib",
+    "version": "{pdfium-branch-version}.0.0",
+    "exports": {
+      ".": {
+        "require": "./node/pdfium.js",
+        "import": "./node/pdfium.esm.js"
+      },
+      "./pdfium.wasm": {
+        "require": "./node/pdfium.wasm",
+        "import": "./node/pdfium.esm.wasm"
+      }
+    }
+  }

--- a/modules/wasm.py
+++ b/modules/wasm.py
@@ -645,6 +645,11 @@ def run_task_generate():
                 os.path.join(node_dir, "index.html"),
             )
 
+            f.copy_file(
+                os.path.join(template_dir, "package.json"),
+                os.path.join(main_dir, "package.json"),
+            )
+
             # change template tags
             l.colored("Replacing template tags...", l.YELLOW)
 
@@ -652,6 +657,12 @@ def run_task_generate():
                 os.path.join(node_dir, "index.html"),
                 "{pdfium-branch}",
                 c.pdfium_git_branch,
+            )
+
+            f.replace_in_file(
+                os.path.join(main_dir, "package.json"),
+                "{pdfium-branch-version}",
+                c.pdfium_git_branch.strip("chromium/"),
             )
 
             # test
@@ -748,13 +759,25 @@ def run_task_archive():
                 current_dir, "build", target["target_os"], target["target_cpu"], config
             )
 
+            filter_files = lambda x: (
+                None if "_" in x.name and not x.name.endswith(".h") else x
+            )
+
             tar.add(
                 name=lib_dir,
                 arcname=os.path.basename(lib_dir),
-                filter=lambda x: (
-                    None if "_" in x.name and not x.name.endswith(".h") else x
-                ),
+                filter=filter_files,
             )
+
+            # Create per config "npm install"-compatible tarball
+            per_config_tar = tarfile.open(os.path.join(current_dir, f"wasm-{config}.tgz"), "w:gz")
+            per_config_tar.add(
+                name=lib_dir,
+                # Use "package" as the root directory to be compatible with "npm install"
+                arcname="package",
+                filter=filter_files,
+            )
+            per_config_tar.close()
 
     tar.close()
 


### PR DESCRIPTION
First of all, thank you for maintaining this great project! We really appreciate your effort.

----

## Motivation

We are using wasm build of PDFium from this project in our Web client application by simply vendoring files extracted from the `wasm.tgz`. However, if we can manage the build artifact as an npm dependency, it would make easier to maintain and upgrade.

## Proposal

If we can publish a tarball that is compatible with the format that `npm install` expects to somewhere like GitHub Releases, it allows us to import the artifacts without vendoring them like below.

```console
$ npm install https://github.com/paulocoutinhox/pdfium-lib/releases/download/<version>/wasm-release.tgz
```

```js
import PDFiumModule from "pdfium-lib";
import PDFiumWASM from "pdfium-lib/pdfium.wasm?url";

await PDFiumModule({
    instantiateWasm: (info, callback) => {
        fetch(PDFiumWASM).then((response) => {
            WebAssembly.instantiateStreaming(response, info).then(({ instance }) => callback(instance));
        });
    }
})
```