### PR TITLE
Fix duplicated EXPORTED_RUNTIME_METHODS definition

### DIFF
--- a/modules/wasm.py
+++ b/modules/wasm.py
@@ -624,8 +624,6 @@ def run_task_generate():
             es6_command = [
                 *base_command,
                 "-s" "EXPORT_ES6=1",
-                "-s",
-                'EXPORTED_RUNTIME_METHODS=\'["ccall", "cwrap", "wasmExports", "HEAP8", "HEAP16", "HEAP32", "HEAPU8", "HEAPU16", "HEAPU32", "HEAPF32", "HEAPF64"]\'',
                 "-o",
                 os.path.join(gen_out_dir, "pdfium.esm.js"),
             ]


### PR DESCRIPTION
## Description
When generating the `es6_command`, we don't need to redefine again the `EXPORTED_RUNTIME_METHODS` values, as we are importing base ones using the `*base_command,` and the values are the same for both.

Cheers!