### PR TITLE
render pages into a BGRx bitmap instead of BGRA

### DIFF
--- a/extras/wasm/template/index.html
+++ b/extras/wasm/template/index.html
@@ -497,7 +497,8 @@
             6: "page not found or content error",
         };
 
-        const BITMAP_BGRA = 4;
+        // BGRx, not BGRA: an alpha destination makes blend modes composite against the white fill
+        const BITMAP_BGRX = 3;
         const BYTES_PER_PIXEL = 4;
 
         // viewer tuning
@@ -668,7 +669,7 @@
             const byteCount = pixelWidth * pixelHeight * BYTES_PER_PIXEL;
 
             const bufferPtr = Module.wasmExports.malloc(byteCount);
-            const bitmap = FPDF.Bitmap_CreateEx(pixelWidth, pixelHeight, BITMAP_BGRA, bufferPtr, pixelWidth * BYTES_PER_PIXEL);
+            const bitmap = FPDF.Bitmap_CreateEx(pixelWidth, pixelHeight, BITMAP_BGRX, bufferPtr, pixelWidth * BYTES_PER_PIXEL);
             const page = FPDF.LoadPage(activeDocument.handle, index);
 
             FPDF.Bitmap_FillRect(bitmap, 0, 0, pixelWidth, pixelHeight, 0xFFFFFFFF);

--- a/sample/src/main.cpp
+++ b/sample/src/main.cpp
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
 
         uint8_t buffer[(int)pageWidth * (int)pageHeight * 4];
 
-        FPDF_BITMAP createdpages = FPDFBitmap_CreateEx((int)pageWidth, (int)pageHeight, 4, buffer, (int)pageWidth * 4);
+        FPDF_BITMAP createdpages = FPDFBitmap_CreateEx((int)pageWidth, (int)pageHeight, FPDFBitmap_BGRx, buffer, (int)pageWidth * 4);
         uint background = 0xFFFFFFFF;
         FPDFBitmap_FillRect(createdpages, 0, 0, (int)pageWidth, (int)pageHeight, background);
         FPDF_RenderPageBitmap(createdpages, page, 0, 0, (int)pageWidth, (int)pageHeight, 0, FPDF_ANNOT);


### PR DESCRIPTION
An alpha destination makes pdfium composite transparency groups against the opaque white fill, so a non-normal blend mode such as /BM /Overlay collapses the whole group to white and its content disappears.