### PR TITLE
render pdf pages in a web worker

### DIFF
--- a/extras/wasm/template/index.html
+++ b/extras/wasm/template/index.html
@@ -35,8 +35,6 @@
         })();
     </script>
 
-    <script src="pdfium.js?v={pdfium-branch}"></script>
-
     <style>
         :root {
             --viewer-bg: #525659;
@@ -481,25 +479,9 @@
     </div>
 
     <script>
-        // pdfium render flags and bitmap constants
-        const FPDF_FLAGS = {
-            ANNOT: 0x01,
-            REVERSE_BYTE_ORDER: 0x10,
-        };
-
-        const LAST_ERROR = {
-            0: "success",
-            1: "unknown error",
-            2: "file not found or could not be opened",
-            3: "file not in PDF format or corrupted",
-            4: "password required or incorrect password",
-            5: "unsupported security scheme",
-            6: "page not found or content error",
-        };
-
-        // BGRx, not BGRA: an alpha destination makes blend modes composite against the white fill
-        const BITMAP_BGRX = 3;
-        const BYTES_PER_PIXEL = 4;
+        // the engine version, replaced at build time, busts the cache of the worker and
+        // of every asset it loads whenever a new release is published
+        const PDFIUM_VERSION = "{pdfium-branch}";
 
         // viewer tuning
         const MIN_ZOOM = 0.25;
@@ -507,19 +489,28 @@
         const ZOOM_STEP = 0.2;
         const RENDER_MARGIN_RATIO = 1.5;
         const MAX_PIXEL_DIMENSION = 4096;
+        const PREVIEW_MAX_WIDTH = 320;
+        const PREVIEW_CACHE_LIMIT = 60;
         const PIXEL_RATIO = Math.min(window.devicePixelRatio || 1, 2);
 
-        let Module = null;
-        const FPDF = {};
+        let worker = null;
 
-        // document holds the live pdfium handles, the source bytes and the read callback
+        // document holds the page geometry and the source blob, never the pdfium handles
         let activeDocument = null;
         let zoom = 1.0;
         let fitMode = true;
         let currentPage = 1;
-        let renderQueue = [];
-        let pumpScheduled = false;
         let scrollRaf = null;
+
+        // renders in flight are tagged with a generation so a zoom can invalidate them
+        let generation = 0;
+        let openRequest = null;
+
+        // cheap previews are kept for the whole document, full renders only while on screen
+        const previewCache = new Map();
+        const requestedPreviews = new Set();
+        const requestedFull = new Map();
+        const fullPages = new Set();
 
         // dom references
         const dom = {};
@@ -528,97 +519,96 @@
         let markEngineReady;
         const engineReady = new Promise((resolve) => { markEngineReady = resolve; });
 
-        // pdfium module bootstrap
-        PDFiumModule().then((instance) => {
-            Module = instance;
-            bindFunctions();
-            FPDF.Init();
-            markEngineReady();
-            setLoading(false);
-            log("Engine ready");
-        });
+        function startWorker() {
+            worker = new Worker('pdfium-worker.js?v=' + encodeURIComponent(PDFIUM_VERSION));
+            worker.onmessage = (event) => onWorkerMessage(event.data);
 
-        function bindFunctions() {
-            FPDF.Init = Module.cwrap('PDFium_Init');
-            FPDF.LoadCustomDocument = Module.cwrap('FPDF_LoadCustomDocument', 'number', ['number', 'string']);
-            FPDF.CloseDocument = Module.cwrap('FPDF_CloseDocument', '', ['number']);
-            FPDF.GetPageCount = Module.cwrap('FPDF_GetPageCount', 'number', ['number']);
-            FPDF.GetPageSizeByIndex = Module.cwrap('FPDF_GetPageSizeByIndex', 'number', ['number', 'number', 'number', 'number']);
-            FPDF.GetLastError = Module.cwrap('FPDF_GetLastError', 'number');
-            FPDF.LoadPage = Module.cwrap('FPDF_LoadPage', 'number', ['number', 'number']);
-            FPDF.ClosePage = Module.cwrap('FPDF_ClosePage', '', ['number']);
-            FPDF.RenderPageBitmap = Module.cwrap('FPDF_RenderPageBitmap', '', ['number', 'number', 'number', 'number', 'number', 'number', 'number', 'number']);
-            FPDF.Bitmap_CreateEx = Module.cwrap('FPDFBitmap_CreateEx', 'number', ['number', 'number', 'number', 'number', 'number']);
-            FPDF.Bitmap_FillRect = Module.cwrap('FPDFBitmap_FillRect', '', ['number', 'number', 'number', 'number', 'number', 'number']);
-            FPDF.Bitmap_Destroy = Module.cwrap('FPDFBitmap_Destroy', '', ['number']);
+            worker.onerror = (event) => {
+                setLoading(false);
+                showError("the render engine failed to start");
+                log("Worker error: " + (event.message || "unknown"));
+            };
         }
 
-        // streaming loader: pdfium reads only the blocks it needs from the source bytes
-        function openDocument(bytes, name, password = "") {
-            closeDocument();
+        function onWorkerMessage(message) {
+            switch (message.type) {
+                case 'ready':
+                    markEngineReady();
+                    setLoading(false);
+                    log("Engine ready");
+                    break;
 
-            // register the block reader so pdfium can pull ranges on demand
-            const readBlock = (param, position, bufferPtr, size) => {
-                Module.HEAPU8.set(bytes.subarray(position, position + size), bufferPtr);
-                return 1;
-            };
+                case 'opened':
+                    onDocumentOpened(message);
+                    break;
 
-            const readerPtr = Module.addFunction(readBlock, 'iiiii');
+                case 'openError':
+                    onDocumentFailed(message);
+                    break;
 
-            // build the FPDF_FILEACCESS struct: m_FileLen, m_GetBlock, m_Param
-            const fileAccessPtr = Module.wasmExports.malloc(12);
-            Module.setValue(fileAccessPtr + 0, bytes.length, 'i32');
-            Module.setValue(fileAccessPtr + 4, readerPtr, 'i32');
-            Module.setValue(fileAccessPtr + 8, 0, 'i32');
+                case 'rendered':
+                    onPageRendered(message);
+                    break;
 
-            const handle = FPDF.LoadCustomDocument(fileAccessPtr, password);
-
-            // the struct is no longer needed once the document is created
-            Module.wasmExports.free(fileAccessPtr);
-
-            if (!handle) {
-                Module.removeFunction(readerPtr);
-
-                const code = FPDF.GetLastError();
-
-                // ask for a password when the document is protected
-                if (code === 4) {
-                    const entered = window.prompt("This PDF is password protected. Enter the password:");
-
-                    if (entered !== null) {
-                        openDocument(bytes, name, entered);
-                        return;
-                    }
-                }
-
-                throw new Error(LAST_ERROR[code] || "could not open document");
+                case 'renderError':
+                    log("Page " + (message.index + 1) + " failed: " + message.message);
+                    break;
             }
+        }
 
-            const pageCount = FPDF.GetPageCount(handle);
+        // the buffer moves to the worker, the blob stays here so downloads cost no extra memory
+        function openDocument(buffer, name, blob) {
+            return new Promise((resolve, reject) => {
+                closeDocument();
 
-            // reject documents that opened but carry no pages
-            if (pageCount <= 0) {
-                FPDF.CloseDocument(handle);
-                Module.removeFunction(readerPtr);
-                throw new Error("this document has no pages");
+                openRequest = { resolve, reject, name, blob };
+                worker.postMessage({ type: 'open', buffer }, [buffer]);
+            });
+        }
+
+        function onDocumentOpened(message) {
+            const request = openRequest;
+            openRequest = null;
+
+            if (!request) {
+                return;
             }
 
             activeDocument = {
-                handle,
-                readerPtr,
-                bytes,
-                name,
-                pageCount,
-                sizes: new Array(pageCount).fill(null),
-                rendered: new Set(),
+                name: request.name,
+                blob: request.blob,
+                pageCount: message.pageCount,
+                sizes: message.sizes,
             };
 
-            log('Opened "' + name + '" with ' + pageCount + ' page(s)');
+            log('Opened "' + request.name + '" with ' + message.pageCount + ' page(s)');
 
             // show the viewer first so the container has a real width to measure against
-            showViewer(name, pageCount);
+            showViewer(request.name, message.pageCount);
             buildPages();
             fitWidth();
+
+            request.resolve();
+        }
+
+        function onDocumentFailed(message) {
+            const request = openRequest;
+
+            // ask for a password when the document is protected, reusing the bytes the worker holds
+            if (message.needsPassword) {
+                const entered = window.prompt("This PDF is password protected. Enter the password:");
+
+                if (entered !== null) {
+                    worker.postMessage({ type: 'open', password: entered });
+                    return;
+                }
+            }
+
+            openRequest = null;
+
+            if (request) {
+                request.reject(new Error(message.message));
+            }
         }
 
         function closeDocument() {
@@ -626,63 +616,26 @@
                 return;
             }
 
-            FPDF.CloseDocument(activeDocument.handle);
-            Module.removeFunction(activeDocument.readerPtr);
-
+            worker.postMessage({ type: 'close' });
+            discardCaches();
             activeDocument = null;
-            renderQueue = [];
         }
 
-        // page size is cheap and does not require loading the full page
-        function getPageSize(index) {
-            const cached = activeDocument.sizes[index];
-
-            if (cached) {
-                return cached;
+        function discardCaches() {
+            for (const preview of previewCache.values()) {
+                releasePaintable(preview);
             }
 
-            const widthPtr = Module.wasmExports.malloc(8);
-            const heightPtr = Module.wasmExports.malloc(8);
-
-            FPDF.GetPageSizeByIndex(activeDocument.handle, index, widthPtr, heightPtr);
-
-            // read the doubles straight from the heap, malloc keeps them 8-byte aligned
-            const size = {
-                width: Module.HEAPF64[widthPtr >> 3],
-                height: Module.HEAPF64[heightPtr >> 3],
-            };
-
-            Module.wasmExports.free(widthPtr);
-            Module.wasmExports.free(heightPtr);
-
-            activeDocument.sizes[index] = size;
-            return size;
+            previewCache.clear();
+            requestedPreviews.clear();
+            requestedFull.clear();
+            fullPages.clear();
+            generation++;
         }
 
-        // render a single page into an image bitmap at the current zoom
-        function renderPage(index) {
-            const size = getPageSize(index);
-            const scale = Math.min(zoom * PIXEL_RATIO, MAX_PIXEL_DIMENSION / Math.max(size.width, size.height));
-
-            const pixelWidth = Math.max(1, Math.ceil(size.width * scale));
-            const pixelHeight = Math.max(1, Math.ceil(size.height * scale));
-            const byteCount = pixelWidth * pixelHeight * BYTES_PER_PIXEL;
-
-            const bufferPtr = Module.wasmExports.malloc(byteCount);
-            const bitmap = FPDF.Bitmap_CreateEx(pixelWidth, pixelHeight, BITMAP_BGRX, bufferPtr, pixelWidth * BYTES_PER_PIXEL);
-            const page = FPDF.LoadPage(activeDocument.handle, index);
-
-            FPDF.Bitmap_FillRect(bitmap, 0, 0, pixelWidth, pixelHeight, 0xFFFFFFFF);
-            FPDF.RenderPageBitmap(bitmap, page, 0, 0, pixelWidth, pixelHeight, 0, FPDF_FLAGS.REVERSE_BYTE_ORDER | FPDF_FLAGS.ANNOT);
-
-            // copy pixels out of the heap before releasing the native buffer
-            const pixels = new Uint8ClampedArray(Module.HEAPU8.buffer, bufferPtr, byteCount).slice();
-
-            FPDF.ClosePage(page);
-            FPDF.Bitmap_Destroy(bitmap);
-            Module.wasmExports.free(bufferPtr);
-
-            return new ImageData(pixels, pixelWidth, pixelHeight);
+        // the scale a page is rendered at, capped so huge pages never blow up the bitmap
+        function renderScale(size) {
+            return Math.min(zoom * PIXEL_RATIO, MAX_PIXEL_DIMENSION / Math.max(size.width, size.height));
         }
 
         // build placeholder elements sized by page aspect ratio without rendering yet
@@ -694,22 +647,22 @@
             currentPage = 1;
 
             for (let index = 0; index < activeDocument.pageCount; index++) {
-                const size = getPageSize(index);
-
                 const page = document.createElement('div');
                 page.className = "page";
                 page.dataset.index = index;
-
-                const placeholder = document.createElement('div');
-                placeholder.className = "page-placeholder";
-                placeholder.innerHTML = '<div class="page-spinner"></div>';
-                page.appendChild(placeholder);
+                page.appendChild(buildPlaceholder());
 
                 dom.pagesContainer.appendChild(page);
-                applyPageSize(page, size);
+                applyPageSize(page, activeDocument.sizes[index]);
             }
+        }
 
-            refreshVisiblePages();
+        function buildPlaceholder() {
+            const placeholder = document.createElement('div');
+            placeholder.className = "page-placeholder";
+            placeholder.innerHTML = '<div class="page-spinner"></div>';
+
+            return placeholder;
         }
 
         function applyPageSize(page, size) {
@@ -717,20 +670,21 @@
             page.style.height = Math.round(size.height * zoom) + "px";
         }
 
-        // decide which pages to render and which to release based on the viewport
+        // decide which pages to request and which to drop back to a preview
         function refreshVisiblePages() {
             const container = dom.pagesContainer;
             const margin = container.clientHeight * RENDER_MARGIN_RATIO;
             const top = container.scrollTop - margin;
             const bottom = container.scrollTop + container.clientHeight + margin;
+            const center = container.scrollTop + container.clientHeight / 2;
 
             for (const page of container.children) {
                 const index = Number(page.dataset.index);
                 const visible = page.offsetTop + page.offsetHeight >= top && page.offsetTop <= bottom;
 
-                if (visible && !activeDocument.rendered.has(index)) {
-                    enqueueRender(index);
-                } else if (!visible && activeDocument.rendered.has(index)) {
+                if (visible) {
+                    requestPage(index, Math.abs(page.offsetTop + page.offsetHeight / 2 - center));
+                } else if (fullPages.has(index) || requestedFull.has(index)) {
                     releasePage(page, index);
                 }
             }
@@ -738,60 +692,149 @@
             updateCurrentPage();
         }
 
-        function enqueueRender(index) {
-            if (!renderQueue.includes(index)) {
-                renderQueue.push(index);
-                schedulePump();
+        // ask for a coarse preview once, then the sharp render for the current zoom
+        function requestPage(index, priority) {
+            const size = activeDocument.sizes[index];
+            const scale = renderScale(size);
+            const previewScale = Math.min(scale, PREVIEW_MAX_WIDTH / size.width);
+
+            if (requestedPreviews.has(index)) {
+                // a page on screen is in use, so it must not be the next preview evicted
+                touchPreview(index);
+            } else {
+                requestedPreviews.add(index);
+                worker.postMessage({ type: 'render', index, scale: previewScale, quality: 'preview', gen: generation, priority });
+            }
+
+            if (requestedFull.get(index) !== scale) {
+                requestedFull.set(index, scale);
+                worker.postMessage({ type: 'render', index, scale, quality: 'full', gen: generation, priority });
             }
         }
 
-        // render one page per frame to keep scrolling smooth
-        function schedulePump() {
-            if (pumpScheduled) {
+        function onPageRendered(message) {
+            const image = toPaintable(message);
+
+            // a render that finished after a zoom or a close is no longer wanted
+            if (message.gen < generation || !activeDocument) {
+                releasePaintable(image);
                 return;
             }
 
-            pumpScheduled = true;
+            const page = dom.pagesContainer.children[message.index];
 
-            requestAnimationFrame(() => {
-                pumpScheduled = false;
+            if (!page) {
+                releasePaintable(image);
+                return;
+            }
 
-                const index = renderQueue.shift();
+            if (message.quality === 'preview') {
+                cachePreview(message.index, image);
 
-                if (index === undefined || !activeDocument) {
-                    return;
+                // a sharp render already on screen must not be replaced by the preview
+                if (!fullPages.has(message.index)) {
+                    paint(page, image, false);
                 }
 
-                paintPage(index);
+                return;
+            }
 
-                if (renderQueue.length > 0) {
-                    schedulePump();
-                }
-            });
+            // the page may have scrolled out of range while this render was in flight,
+            // in which case releasePage already dropped the request and we throw it away
+            if (requestedFull.get(message.index) !== message.scale) {
+                releasePaintable(image);
+                return;
+            }
+
+            paint(page, image, true);
+            fullPages.add(message.index);
         }
 
-        function paintPage(index) {
-            const page = dom.pagesContainer.children[index];
+        // previews are small but a long document still adds up, so keep the recent ones only
+        function cachePreview(index, image) {
+            releasePaintable(previewCache.get(index));
+            previewCache.delete(index);
+            previewCache.set(index, image);
 
-            if (!page || activeDocument.rendered.has(index)) {
-                return;
+            while (previewCache.size > PREVIEW_CACHE_LIMIT) {
+                const oldest = previewCache.keys().next().value;
+
+                releasePaintable(previewCache.get(oldest));
+                previewCache.delete(oldest);
+                requestedPreviews.delete(oldest);
+            }
+        }
+
+        // re-inserting moves the entry to the end, which is what keeps the eviction order honest
+        function touchPreview(index) {
+            const image = previewCache.get(index);
+
+            if (!image) {
+                return null;
             }
 
-            const imageData = renderPage(index);
+            previewCache.delete(index);
+            previewCache.set(index, image);
 
+            return image;
+        }
+
+        function toPaintable(message) {
+            if (message.bitmap) {
+                return { bitmap: message.bitmap };
+            }
+
+            return { imageData: new ImageData(new Uint8ClampedArray(message.pixels), message.width, message.height) };
+        }
+
+        function releasePaintable(image) {
+            if (image && image.bitmap) {
+                image.bitmap.close();
+            }
+        }
+
+        // consume hands the bitmap straight to the canvas without a copy, which empties it,
+        // so only one-shot full renders do it and cached previews are drawn instead
+        function paint(page, image, consume) {
             const canvas = document.createElement('canvas');
-            canvas.width = imageData.width;
-            canvas.height = imageData.height;
-            canvas.getContext('2d').putImageData(imageData, 0, 0);
 
-            page.innerHTML = "";
-            page.appendChild(canvas);
-            activeDocument.rendered.add(index);
+            if (image.bitmap && consume) {
+                canvas.width = image.bitmap.width;
+                canvas.height = image.bitmap.height;
+                canvas.getContext('bitmaprenderer').transferFromImageBitmap(image.bitmap);
+            } else if (image.bitmap) {
+                canvas.width = image.bitmap.width;
+                canvas.height = image.bitmap.height;
+                canvas.getContext('2d').drawImage(image.bitmap, 0, 0);
+            } else {
+                canvas.width = image.imageData.width;
+                canvas.height = image.imageData.height;
+                canvas.getContext('2d').putImageData(image.imageData, 0, 0);
+            }
+
+            page.replaceChildren(canvas);
         }
 
+        // scrolling away drops the sharp render but keeps the preview on screen
         function releasePage(page, index) {
-            page.innerHTML = '<div class="page-placeholder"><div class="page-spinner"></div></div>';
-            activeDocument.rendered.delete(index);
+            const hadFull = fullPages.delete(index);
+
+            // a render still queued for a page nobody is looking at is wasted work
+            if (requestedFull.delete(index)) {
+                worker.postMessage({ type: 'drop', index });
+            }
+
+            if (!hadFull) {
+                return;
+            }
+
+            const preview = touchPreview(index);
+
+            if (preview) {
+                paint(page, preview, false);
+            } else {
+                page.replaceChildren(buildPlaceholder());
+            }
         }
 
         // find the page closest to the viewport center for the page indicator
@@ -827,21 +870,22 @@
             }
         }
 
-        // re-layout every page when the zoom changes and re-render what is visible
+        // re-layout every page when the zoom changes and re-render what is visible.
+        // the canvases already on screen are left in place and stretched by css, so the
+        // page never flashes back to a spinner while the sharper render is on its way
         function applyZoom(nextZoom) {
             zoom = Math.min(Math.max(nextZoom, MIN_ZOOM), MAX_ZOOM);
             dom.zoomLevel.textContent = Math.round(zoom * 100) + "%";
 
             for (const page of dom.pagesContainer.children) {
-                const index = Number(page.dataset.index);
-                applyPageSize(page, getPageSize(index));
-
-                if (activeDocument.rendered.has(index)) {
-                    releasePage(page, index);
-                }
+                applyPageSize(page, activeDocument.sizes[Number(page.dataset.index)]);
             }
 
-            renderQueue = [];
+            // drop everything still queued at the old scale before asking for the new one
+            generation++;
+            requestedFull.clear();
+            worker.postMessage({ type: 'cancel', gen: generation });
+
             refreshVisiblePages();
         }
 
@@ -857,8 +901,8 @@
 
             let widest = 0;
 
-            for (let index = 0; index < activeDocument.pageCount; index++) {
-                widest = Math.max(widest, getPageSize(index).width);
+            for (const size of activeDocument.sizes) {
+                widest = Math.max(widest, size.width);
             }
 
             fitMode = true;
@@ -872,8 +916,7 @@
                 log('Reading file "' + file.name + '"');
 
                 await engineReady;
-                const buffer = await file.arrayBuffer();
-                openDocument(new Uint8Array(buffer), file.name);
+                await openDocument(await file.arrayBuffer(), file.name, file);
 
                 setLoading(false);
             } catch (error) {
@@ -894,9 +937,9 @@
                     throw new Error("could not download the file");
                 }
 
-                const buffer = await response.arrayBuffer();
+                const blob = await response.blob();
                 const name = decodeURIComponent(url.split('/').pop() || "document.pdf");
-                openDocument(new Uint8Array(buffer), name);
+                await openDocument(await blob.arrayBuffer(), name, blob);
 
                 setLoading(false);
             } catch (error) {
@@ -906,10 +949,13 @@
         }
 
         function downloadActive() {
-            const blob = new Blob([activeDocument.bytes], { type: 'application/pdf' });
+            if (!activeDocument) {
+                return;
+            }
+
             const link = document.createElement('a');
 
-            link.href = URL.createObjectURL(blob);
+            link.href = URL.createObjectURL(activeDocument.blob);
             link.download = activeDocument.name;
             link.click();
 
@@ -1174,13 +1220,14 @@
                 dom[id] = document.getElementById(id);
             }
 
-            if (!('WebAssembly' in window)) {
+            if (!('WebAssembly' in window) || !('Worker' in window)) {
                 setLoading(false);
-                showError("Your browser does not support WebAssembly.");
+                showError("Your browser does not support WebAssembly workers.");
                 return;
             }
 
             setupTheme();
+            startWorker();
             bindEvents();
             applyUrlParams();
         }

--- a/extras/wasm/template/pdfium-worker.js
+++ b/extras/wasm/template/pdfium-worker.js
@@ -1,0 +1,306 @@
+// pdfium runs here so that rendering never blocks the ui thread.
+// the version comes from the worker url and is forwarded to every asset it loads,
+// so publishing a new release busts the cache of the worker and of the engine together.
+const VERSION = new URLSearchParams(self.location.search).get('v') || "";
+const VERSION_QUERY = VERSION ? "?v=" + encodeURIComponent(VERSION) : "";
+
+importScripts('pdfium.js' + VERSION_QUERY);
+
+const FPDF_FLAGS = {
+    ANNOT: 0x01,
+    REVERSE_BYTE_ORDER: 0x10,
+};
+
+const LAST_ERROR = {
+    0: "success",
+    1: "unknown error",
+    2: "file not found or could not be opened",
+    3: "file not in PDF format or corrupted",
+    4: "password required or incorrect password",
+    5: "unsupported security scheme",
+    6: "page not found or content error",
+};
+
+const PASSWORD_ERROR = 4;
+
+// BGRx, not BGRA: an alpha destination makes blend modes composite against the white fill
+const BITMAP_BGRX = 3;
+const BYTES_PER_PIXEL = 4;
+
+let Module = null;
+const FPDF = {};
+
+// the bytes of the last open attempt, kept so a password retry does not resend them
+let sourceBytes = null;
+let activeDocument = null;
+
+// jobs waiting to be rendered, plus the generation that decides which ones are still wanted
+let queue = [];
+let generation = 0;
+let drainScheduled = false;
+
+PDFiumModule().then((instance) => {
+    Module = instance;
+    bindFunctions();
+    FPDF.Init();
+    self.postMessage({ type: 'ready' });
+});
+
+function bindFunctions() {
+    FPDF.Init = Module.cwrap('PDFium_Init');
+    FPDF.LoadCustomDocument = Module.cwrap('FPDF_LoadCustomDocument', 'number', ['number', 'string']);
+    FPDF.CloseDocument = Module.cwrap('FPDF_CloseDocument', '', ['number']);
+    FPDF.GetPageCount = Module.cwrap('FPDF_GetPageCount', 'number', ['number']);
+    FPDF.GetPageSizeByIndex = Module.cwrap('FPDF_GetPageSizeByIndex', 'number', ['number', 'number', 'number', 'number']);
+    FPDF.GetLastError = Module.cwrap('FPDF_GetLastError', 'number');
+    FPDF.LoadPage = Module.cwrap('FPDF_LoadPage', 'number', ['number', 'number']);
+    FPDF.ClosePage = Module.cwrap('FPDF_ClosePage', '', ['number']);
+    FPDF.RenderPageBitmap = Module.cwrap('FPDF_RenderPageBitmap', '', ['number', 'number', 'number', 'number', 'number', 'number', 'number', 'number']);
+    FPDF.Bitmap_CreateEx = Module.cwrap('FPDFBitmap_CreateEx', 'number', ['number', 'number', 'number', 'number', 'number']);
+    FPDF.Bitmap_FillRect = Module.cwrap('FPDFBitmap_FillRect', '', ['number', 'number', 'number', 'number', 'number', 'number']);
+    FPDF.Bitmap_Destroy = Module.cwrap('FPDFBitmap_Destroy', '', ['number']);
+}
+
+self.onmessage = (event) => {
+    const message = event.data;
+
+    switch (message.type) {
+        case 'open':
+            open(message);
+            break;
+
+        case 'close':
+            closeDocument();
+            break;
+
+        case 'render':
+            enqueue(message);
+            break;
+
+        case 'drop':
+            queue = queue.filter((job) => job.index !== message.index || job.quality !== 'full');
+            break;
+
+        case 'cancel':
+            generation = message.gen;
+            queue = queue.filter((job) => job.gen >= generation);
+            break;
+    }
+};
+
+// streaming loader: pdfium reads only the blocks it needs from the source bytes
+function open(message) {
+    closeDocument();
+
+    if (message.buffer) {
+        sourceBytes = new Uint8Array(message.buffer);
+    }
+
+    if (!sourceBytes) {
+        self.postMessage({ type: 'openError', message: "no document to open" });
+        return;
+    }
+
+    // pdfium keeps calling this while the document is open, so the bytes must outlive it
+    const bytes = sourceBytes;
+
+    const readBlock = (param, position, bufferPtr, size) => {
+        Module.HEAPU8.set(bytes.subarray(position, position + size), bufferPtr);
+        return 1;
+    };
+
+    const readerPtr = Module.addFunction(readBlock, 'iiiii');
+
+    // build the FPDF_FILEACCESS struct: m_FileLen, m_GetBlock, m_Param
+    const fileAccessPtr = Module.wasmExports.malloc(12);
+    Module.setValue(fileAccessPtr + 0, bytes.length, 'i32');
+    Module.setValue(fileAccessPtr + 4, readerPtr, 'i32');
+    Module.setValue(fileAccessPtr + 8, 0, 'i32');
+
+    const handle = FPDF.LoadCustomDocument(fileAccessPtr, message.password || "");
+
+    // the struct is no longer needed once the document is created
+    Module.wasmExports.free(fileAccessPtr);
+
+    if (!handle) {
+        Module.removeFunction(readerPtr);
+
+        const code = FPDF.GetLastError();
+
+        self.postMessage({
+            type: 'openError',
+            message: LAST_ERROR[code] || "could not open document",
+            needsPassword: code === PASSWORD_ERROR,
+        });
+
+        return;
+    }
+
+    const pageCount = FPDF.GetPageCount(handle);
+
+    // reject documents that opened but carry no pages
+    if (pageCount <= 0) {
+        FPDF.CloseDocument(handle);
+        Module.removeFunction(readerPtr);
+        self.postMessage({ type: 'openError', message: "this document has no pages" });
+        return;
+    }
+
+    activeDocument = { handle, readerPtr, bytes, pageCount, sizes: readPageSizes(handle, pageCount) };
+
+    self.postMessage({
+        type: 'opened',
+        pageCount,
+        sizes: activeDocument.sizes,
+    });
+}
+
+function closeDocument() {
+    queue = [];
+
+    if (!activeDocument) {
+        return;
+    }
+
+    FPDF.CloseDocument(activeDocument.handle);
+    Module.removeFunction(activeDocument.readerPtr);
+    activeDocument = null;
+}
+
+// page sizes are cheap and do not require loading the pages themselves
+function readPageSizes(handle, pageCount) {
+    const widthPtr = Module.wasmExports.malloc(8);
+    const heightPtr = Module.wasmExports.malloc(8);
+    const sizes = [];
+
+    for (let index = 0; index < pageCount; index++) {
+        FPDF.GetPageSizeByIndex(handle, index, widthPtr, heightPtr);
+
+        // read the doubles straight from the heap, malloc keeps them 8-byte aligned
+        sizes.push({
+            width: Module.HEAPF64[widthPtr >> 3],
+            height: Module.HEAPF64[heightPtr >> 3],
+        });
+    }
+
+    Module.wasmExports.free(widthPtr);
+    Module.wasmExports.free(heightPtr);
+
+    return sizes;
+}
+
+// a newer request for the same page and quality replaces the one still waiting
+function enqueue(job) {
+    if (job.gen > generation) {
+        generation = job.gen;
+    }
+
+    queue = queue.filter((other) => other.index !== job.index || other.quality !== job.quality);
+    queue.push(job);
+    scheduleDrain();
+}
+
+function scheduleDrain() {
+    if (drainScheduled) {
+        return;
+    }
+
+    drainScheduled = true;
+
+    // a macrotask, not a microtask: it lets pending messages land between two renders,
+    // which is what makes cancelling a fast scroll or a zoom actually take effect
+    setTimeout(drain, 0);
+}
+
+// pick the most useful job: previews before full renders, then closest to the viewport
+function takeNext() {
+    let best = -1;
+
+    for (let index = 0; index < queue.length; index++) {
+        const job = queue[index];
+
+        if (job.gen < generation) {
+            continue;
+        }
+
+        if (best < 0) {
+            best = index;
+            continue;
+        }
+
+        const current = queue[best];
+        const jobRank = job.quality === 'preview' ? 0 : 1;
+        const bestRank = current.quality === 'preview' ? 0 : 1;
+
+        if (jobRank < bestRank || (jobRank === bestRank && job.priority < current.priority)) {
+            best = index;
+        }
+    }
+
+    if (best < 0) {
+        queue = [];
+        return null;
+    }
+
+    const job = queue[best];
+    queue = queue.filter((other) => other !== job && other.gen >= generation);
+
+    return job;
+}
+
+async function drain() {
+    drainScheduled = false;
+
+    const job = takeNext();
+
+    if (!job || !activeDocument) {
+        return;
+    }
+
+    try {
+        const image = renderPage(job);
+        const payload = { type: 'rendered', index: job.index, quality: job.quality, gen: job.gen, scale: job.scale, width: image.width, height: image.height };
+
+        // an ImageBitmap transfers without a copy and paints without touching the cpu
+        if (typeof createImageBitmap === 'function') {
+            const bitmap = await createImageBitmap(image);
+            self.postMessage({ ...payload, bitmap }, [bitmap]);
+        } else {
+            self.postMessage({ ...payload, pixels: image.data.buffer }, [image.data.buffer]);
+        }
+    } catch (error) {
+        self.postMessage({ type: 'renderError', index: job.index, message: String(error && error.message || error) });
+    }
+
+    if (queue.length > 0) {
+        scheduleDrain();
+    }
+}
+
+function renderPage(job) {
+    const size = activeDocument.sizes[job.index];
+    const width = Math.max(1, Math.ceil(size.width * job.scale));
+    const height = Math.max(1, Math.ceil(size.height * job.scale));
+    const byteCount = width * height * BYTES_PER_PIXEL;
+
+    const page = FPDF.LoadPage(activeDocument.handle, job.index);
+
+    if (!page) {
+        throw new Error("could not load page " + (job.index + 1));
+    }
+
+    const bufferPtr = Module.wasmExports.malloc(byteCount);
+    const bitmap = FPDF.Bitmap_CreateEx(width, height, BITMAP_BGRX, bufferPtr, width * BYTES_PER_PIXEL);
+
+    FPDF.Bitmap_FillRect(bitmap, 0, 0, width, height, 0xFFFFFFFF);
+    FPDF.RenderPageBitmap(bitmap, page, 0, 0, width, height, 0, FPDF_FLAGS.REVERSE_BYTE_ORDER | FPDF_FLAGS.ANNOT);
+
+    // copy pixels out of the heap before releasing the native buffer
+    const pixels = new Uint8ClampedArray(Module.HEAPU8.buffer, bufferPtr, byteCount).slice();
+
+    FPDF.Bitmap_Destroy(bitmap);
+    Module.wasmExports.free(bufferPtr);
+    FPDF.ClosePage(page);
+
+    return new ImageData(pixels, width, height);
+}

--- a/modules/wasm.py
+++ b/modules/wasm.py
@@ -822,6 +822,11 @@ def run_task_generate():
             )
 
             f.copy_file(
+                os.path.join(template_dir, "pdfium-worker.js"),
+                os.path.join(node_dir, "pdfium-worker.js"),
+            )
+
+            f.copy_file(
                 os.path.join(template_dir, "logo.png"),
                 os.path.join(node_dir, "logo.png"),
             )


### PR DESCRIPTION
FPDF_RenderPageBitmap is one atomic synchronous call, so spreading pages across animation frames never helped: a single heavy page froze the tab for as long as it took to render. Measured natively on a 13 page report, one page costs 2.4s.

pdfium now lives in a worker that owns the document and streams finished pages back as transferable ImageBitmaps. Pages are requested twice, once as a cheap preview and once at the current zoom, and a generation counter plus per-page drops let the worker skip renders the viewer no longer wants. Previews are kept in a bounded cache so scrolling back and zooming never fall back to a spinner.

The worker url carries the engine version, which it forwards to importScripts, so a new release busts the cache of the worker and of the engine together.