### PR TITLE
add support for linux and windows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,114 @@
+name: Linux
+
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'extras/images/**'
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { name: "Linux", os: "ubuntu-22.04", target: "linux" }
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install System Packages
+        run: |
+          sudo apt-get -y update && \
+          sudo apt-get -y install build-essential pkg-config && \
+          sudo rm -rf /var/lib/apt/lists/* && \
+          sudo apt-get clean
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Upgrade PIP
+        run: python3 -m pip install --upgrade pip setuptools wheel
+
+      - name: Install CMake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: "3.24.0"
+
+      - name: Install Ninja
+        uses: seanmiddleditch/gha-setup-ninja@master
+        with:
+          version: "1.12.1"
+
+      - name: Verify
+        run: |
+          python3 --version
+          cmake --version
+          ninja --version
+
+      - name: Python requirements
+        run: python3 -m pip install -r requirements.txt --user
+
+      - name: Depot tools
+        run: python3 make.py build-depot-tools
+
+      - name: Environment
+        run: echo "$PWD/build/depot-tools" >> $GITHUB_PATH
+
+      - name: PDFium
+        run: python3 make.py build-pdfium-${{ matrix.config.target }}
+
+      - name: Patch
+        run: python3 make.py patch-${{ matrix.config.target }}
+
+      - name: Patch - Check
+        run: python3 make.py patch-${{ matrix.config.target }}
+
+      - name: Build
+        run: python3 make.py build-${{ matrix.config.target }}
+
+      - name: Install
+        run: python3 make.py install-${{ matrix.config.target }}
+
+      - name: Test
+        run: python3 make.py test-${{ matrix.config.target }}
+
+      - name: Archive
+        run: python3 make.py archive-${{ matrix.config.target }}
+
+      - name: Save
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact-${{ matrix.config.target }}
+          path: ${{ matrix.config.target }}.tgz
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Load
+        uses: actions/download-artifact@v4
+        with:
+          name: artifact-linux
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Upload release asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: linux.tgz
+          asset_name: linux.tgz
+          asset_content_type: application/tar+gzip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,20 +18,16 @@ jobs:
           - { name: "Windows", os: "windows-2022", target: "windows" }
 
     env:
-      # use the visual studio already installed on the runner instead of the
-      # internal google toolchain, which is not available outside chromium
+      # Uses the visual studio installed on the runner, since the internal google toolchain is not available outside chromium.
       DEPOT_TOOLS_WIN_TOOLCHAIN: 0
 
-      # DEPOT_TOOLS_UPDATE is deliberately not set to 0 here: on windows that
-      # skips the bootstrap that installs git.bat and the bundled python, and
-      # depot tools then fails on its own internal git calls
+      # Setting DEPOT_TOOLS_UPDATE to 0 here would skip the bootstrap that installs git.bat and the bundled python, and depot tools would then fail on its own internal git calls.
 
     steps:
       - uses: actions/checkout@v4
 
-      # the depot tools bootstrap drops a python3.bat into a directory that
-      # ends up ahead of this one in PATH, so every step below calls this
-      # interpreter by path instead of relying on the name python3
+      # The depot tools bootstrap drops a python3.bat into a directory that ends up ahead of this one in PATH.
+      # Every step below calls this interpreter by path instead of relying on the name python3.
       - name: Set up Python
         id: python
         uses: actions/setup-python@v5

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,10 @@ jobs:
       # use the visual studio already installed on the runner instead of the
       # internal google toolchain, which is not available outside chromium
       DEPOT_TOOLS_WIN_TOOLCHAIN: 0
-      DEPOT_TOOLS_UPDATE: 0
+
+      # DEPOT_TOOLS_UPDATE is deliberately not set to 0 here: on windows that
+      # skips the bootstrap that installs git.bat and the bundled python, and
+      # depot tools then fails on its own internal git calls
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,113 @@
+name: Windows
+
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'extras/images/**'
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { name: "Windows", os: "windows-2022", target: "windows" }
+
+    env:
+      # use the visual studio already installed on the runner instead of the
+      # internal google toolchain, which is not available outside chromium
+      DEPOT_TOOLS_WIN_TOOLCHAIN: 0
+      DEPOT_TOOLS_UPDATE: 0
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Upgrade PIP
+        run: python3 -m pip install --upgrade pip setuptools wheel
+
+      - name: Install CMake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: "3.24.0"
+
+      - name: Install Ninja
+        uses: seanmiddleditch/gha-setup-ninja@master
+        with:
+          version: "1.12.1"
+
+      - name: Verify
+        run: |
+          python3 --version
+          cmake --version
+          ninja --version
+
+      - name: Python requirements
+        run: python3 -m pip install -r requirements.txt --user
+
+      - name: Depot tools
+        run: python3 make.py build-depot-tools
+
+      - name: Environment
+        run: echo "$env:GITHUB_WORKSPACE\build\depot-tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: PDFium
+        run: python3 make.py build-pdfium-${{ matrix.config.target }}
+
+      - name: Patch
+        run: python3 make.py patch-${{ matrix.config.target }}
+
+      - name: Patch - Check
+        run: python3 make.py patch-${{ matrix.config.target }}
+
+      - name: Build
+        run: python3 make.py build-${{ matrix.config.target }}
+
+      - name: Install
+        run: python3 make.py install-${{ matrix.config.target }}
+
+      - name: Test
+        run: python3 make.py test-${{ matrix.config.target }}
+
+      - name: Archive
+        run: python3 make.py archive-${{ matrix.config.target }}
+
+      - name: Save
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact-${{ matrix.config.target }}
+          path: ${{ matrix.config.target }}.tgz
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Load
+        uses: actions/download-artifact@v4
+        with:
+          name: artifact-windows
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Upload release asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: windows.tgz
+          asset_name: windows.tgz
+          asset_content_type: application/tar+gzip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,13 +29,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # the depot tools bootstrap drops a python3.bat into a directory that
+      # ends up ahead of this one in PATH, so every step below calls this
+      # interpreter by path instead of relying on the name python3
       - name: Set up Python
+        id: python
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
       - name: Upgrade PIP
-        run: python3 -m pip install --upgrade pip setuptools wheel
+        run: ${{ steps.python.outputs.python-path }} -m pip install --upgrade pip setuptools wheel
 
       - name: Install CMake
         uses: jwlawson/actions-setup-cmake@v2
@@ -49,39 +53,39 @@ jobs:
 
       - name: Verify
         run: |
-          python3 --version
+          ${{ steps.python.outputs.python-path }} --version
           cmake --version
           ninja --version
 
       - name: Python requirements
-        run: python3 -m pip install -r requirements.txt --user
+        run: ${{ steps.python.outputs.python-path }} -m pip install -r requirements.txt --user
 
       - name: Depot tools
-        run: python3 make.py build-depot-tools
+        run: ${{ steps.python.outputs.python-path }} make.py build-depot-tools
 
       - name: Environment
         run: echo "$env:GITHUB_WORKSPACE\build\depot-tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: PDFium
-        run: python3 make.py build-pdfium-${{ matrix.config.target }}
+        run: ${{ steps.python.outputs.python-path }} make.py build-pdfium-${{ matrix.config.target }}
 
       - name: Patch
-        run: python3 make.py patch-${{ matrix.config.target }}
+        run: ${{ steps.python.outputs.python-path }} make.py patch-${{ matrix.config.target }}
 
       - name: Patch - Check
-        run: python3 make.py patch-${{ matrix.config.target }}
+        run: ${{ steps.python.outputs.python-path }} make.py patch-${{ matrix.config.target }}
 
       - name: Build
-        run: python3 make.py build-${{ matrix.config.target }}
+        run: ${{ steps.python.outputs.python-path }} make.py build-${{ matrix.config.target }}
 
       - name: Install
-        run: python3 make.py install-${{ matrix.config.target }}
+        run: ${{ steps.python.outputs.python-path }} make.py install-${{ matrix.config.target }}
 
       - name: Test
-        run: python3 make.py test-${{ matrix.config.target }}
+        run: ${{ steps.python.outputs.python-path }} make.py test-${{ matrix.config.target }}
 
       - name: Archive
-        run: python3 make.py archive-${{ matrix.config.target }}
+        run: ${{ steps.python.outputs.python-path }} make.py archive-${{ matrix.config.target }}
 
       - name: Save
         uses: actions/upload-artifact@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,141 @@
+# Project conventions
+
+This file records how the project is organised and how work on it is expected to be done.
+Read it before changing anything.
+
+## What this project is
+
+It compiles Google's PDFium into a distributable library for several platforms. It does not
+fork PDFium and it does not vendor its source. Every build clones PDFium from upstream,
+applies the minimum set of patches needed for the target platform, compiles it and stages
+the result. All the value of the project sits in the tooling that makes those steps
+reproducible, so keep the tooling clean and never let a fix drift into a copy of upstream code.
+
+## Layout
+
+```
+make.py                    Task entry point, one task per platform step.
+modules/
+  config.py                Every configurable value: pdfium branch, targets, configurations.
+  common.py                Shared tasks and the gn argument builder.
+  pdfium.py                Cloning and syncing pdfium through gclient.
+  patch.py                 Reusable patches applied to the checkout.
+  <platform>.py            The six tasks of one platform.
+docs/BUILD_<PLATFORM>.md   Build tutorial for one platform.
+.github/workflows/         One workflow per platform, all with the same shape.
+sample/                    Console sample used by the test task on desktop platforms.
+sample-apple/              Xcode sample for macOS and iOS.
+sample-wasm/               Sample for the WASM build.
+extras/wasm/               Files shipped with the WASM package, including the viewer template.
+build/                     Output only, ignored by git, safe to delete at any time.
+```
+
+`build/` holds three different things and the names repeat, so read paths carefully:
+
+```
+build/<platform>/pdfium/          The pdfium checkout.
+build/<platform>/pdfium/build/    chromium/src/build.git, pulled by pdfium's DEPS.
+build/<platform>/<config>/        The staged library and headers, what gets archived.
+```
+
+## Platform modules
+
+Every platform module exposes the same six tasks, in this order, and nothing else:
+
+| Task | What it does |
+| --- | --- |
+| `run_task_build_pdfium` | Clones and syncs pdfium through `modules/pdfium.py`. |
+| `run_task_patch` | Applies the patches the platform needs. Must be idempotent. |
+| `run_task_build` | Runs `gn gen` and `ninja` for every configuration and target. |
+| `run_task_install` | Stages the library and the headers under `build/<platform>/<config>`. |
+| `run_task_test` | Builds the sample against the staged library and runs it. |
+| `run_task_archive` | Packs the staged directory into `<platform>.tgz`. |
+
+Use `modules/macos.py` as the reference when adding a platform. Register the tasks in
+`make.py`, in the docstring and in the dispatch chain, keeping the platform sections in the
+same order in both.
+
+## Configuration
+
+`modules/config.py` is the single source of truth. A value that lives there is never
+repeated anywhere else, and code reads it instead of assuming what it holds. Each platform
+declares three things:
+
+```python
+configurations_<platform> = ["release"]
+shared_lib_<platform> = False
+targets_<platform> = [
+    {"target_os": "linux", "target_cpu": "x64", "pdfium_os": "linux"},
+]
+```
+
+`target_os` names the output directory, `pdfium_os` is the value gn expects, and they differ
+on purpose: `macos` is `mac` to gn, `windows` is `win`. Adding an architecture is one entry
+in the list and nothing else.
+
+Build arguments belong in `get_build_args` in `modules/common.py`, never inline in a platform
+module. Static builds get `pdf_is_complete_lib=true`, and every platform that ships a static
+library also needs `use_custom_libcxx=false`, because the bundled libc++ never reaches a
+static archive and its symbols carry an ABI namespace no system runtime provides.
+
+## Patches
+
+PDFium and the chromium build system it pulls in assume the toolchain Google packages
+internally. Where that assumption does not hold, the patch task rewrites the checkout before
+building. Rules for patches:
+
+- Live in `modules/patch.py`, and are called from a platform's `run_task_patch`.
+- Detect what the machine actually has and adapt to it. Never hardcode a version, a path or a tool location.
+- Are idempotent, because CI runs the patch task twice to prove it. Report `Applied` the first time and `Skipped` afterwards.
+- Are a no-op where they do not apply, so a platform module can call them unconditionally.
+- Touch only files under `build/`, which is disposable. Never patch anything tracked by this repository.
+
+The windows patches are the reference: chromium pins the SDK version in `vs_toolchain.py` and
+`setup_toolchain.py`, and pins the API level in `config/win/BUILD.gn`. Both are rewritten from
+what is installed on the machine.
+
+## Continuous integration
+
+One workflow per platform, all built from the same shape: set up Python, CMake and Ninja,
+install the requirements, clone depot tools, put it on `PATH`, then run the six tasks in
+order, upload the archive, and deploy it on a tag. Keep new workflows aligned with the
+existing ones, and add the badge to `README.md`.
+
+Windows differs in two ways that must not be undone:
+
+- `DEPOT_TOOLS_UPDATE` is never set to `0`, because that skips the bootstrap that installs `git.bat` and the bundled python.
+- Python is invoked by path, because the bootstrap drops a `python3.bat` that ends up ahead of the one on `PATH`.
+
+## Code standard
+
+Python is formatted with `black`, through `python3 make.py format`. Run it before committing.
+
+Modules follow the shape of the existing ones: standard library imports, then `pygemstones`,
+then project modules, each function separated by the `# ---` line already used across the
+project. Build paths with `os.path.join`, never by concatenating strings.
+
+Comments follow one standard, in every language used here:
+
+- Every comment is a complete sentence, starting with a capital letter and ending with a period.
+- One sentence per line. Never wrap a sentence across lines and never continue one on the next line.
+- If more than one sentence is needed, finish the current one before starting the next on the following line.
+- A comment above a function, method, class or module says what it does for the caller, never how it works inside.
+- Keep comments objective and natural, never verbose, fragmented or narrative.
+- When a sentence would start with a lowercase identifier, keep its exact spelling and rewrite the sentence so it is not at the start.
+- Code and comments are written in English.
+
+## What not to do
+
+- Do not probe for one of several possible states when the layout can be pinned instead. Make the outcome deterministic and read it directly.
+- Do not add fallbacks for cases that cannot happen, and do not write code paths that nothing exercises.
+- Do not keep dead or legacy code around. Delete it.
+- Do not hardcode a value that already exists in `modules/config.py`.
+- Do not vendor or commit anything produced under `build/`.
+- Do not fix a platform by special casing it inside shared code when the difference belongs in the platform module.
+
+## Working agreement
+
+Every change goes on its own branch, named in short kebab-case, matching the existing ones
+such as `fix-blend-mode-render`, `better-wasm-viewer` and `support-linux-windows`. Review the
+diff before committing. Push only when asked. Report what was verified and what was not,
+plainly, without overstating.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
   <a href="https://github.com/paulocoutinhox/pdfium-lib/actions/workflows/ios.yml"><img src="https://github.com/paulocoutinhox/pdfium-lib/actions/workflows/ios.yml/badge.svg" alt="PDFium - iOS"></a>
   <a href="https://github.com/paulocoutinhox/pdfium-lib/actions/workflows/macos.yml"><img src="https://github.com/paulocoutinhox/pdfium-lib/actions/workflows/macos.yml/badge.svg" alt="PDFium - macOS"></a>
   <a href="https://github.com/paulocoutinhox/pdfium-lib/actions/workflows/android.yml"><img src="https://github.com/paulocoutinhox/pdfium-lib/actions/workflows/android.yml/badge.svg" alt="PDFium - Android"></a>
+  <a href="https://github.com/paulocoutinhox/pdfium-lib/actions/workflows/linux.yml"><img src="https://github.com/paulocoutinhox/pdfium-lib/actions/workflows/linux.yml/badge.svg" alt="PDFium - Linux"></a>
+  <a href="https://github.com/paulocoutinhox/pdfium-lib/actions/workflows/windows.yml"><img src="https://github.com/paulocoutinhox/pdfium-lib/actions/workflows/windows.yml/badge.svg" alt="PDFium - Windows"></a>
   <a href="https://github.com/paulocoutinhox/pdfium-lib/actions/workflows/wasm.yml"><img src="https://github.com/paulocoutinhox/pdfium-lib/actions/workflows/wasm.yml/badge.svg" alt="PDFium - WASM"></a>
 </p>
 
@@ -27,12 +29,9 @@ This project currently compiles to these platforms:
 - [x] iOS simulator (x86_64, arm64)
 - [X] Android (armv7, armv8, x86, x86_64)
 - [x] macOS (x86_64, arm64)
+- [x] Linux (x86_64)
+- [x] Windows (x86_64)
 - [x] WASM (Web Assembly)
-
-Platforms in roadmap:
-
-- Linux
-- Windows
 
 Obs: PDFium project is from Google and i only patch it to compile to all platforms above. Check all oficial details and PDFium license here:
 
@@ -93,6 +92,14 @@ Check tutorial here: [Build for iOS](docs/BUILD_IOS.md)
 ## How to compile for macOS (with Apple Silicon - M1)
 
 Check tutorial here: [Build for macOS](docs/BUILD_MACOS.md)
+
+## How to compile for Linux
+
+Check tutorial here: [Build for Linux](docs/BUILD_LINUX.md)
+
+## How to compile for Windows
+
+Check tutorial here: [Build for Windows](docs/BUILD_WINDOWS.md)
 
 ## How to compile for Android
 

--- a/docs/BUILD_LINUX.md
+++ b/docs/BUILD_LINUX.md
@@ -39,6 +39,4 @@ targets_linux = [
 ]
 ```
 
-Obs:
-- Cross compiling needs a toolchain for the target architecture.
-- A static `arm64` build also needs `use_lld=false` in `modules/common.py`.
+Obs: cross compiling needs a toolchain for the target architecture.

--- a/docs/BUILD_LINUX.md
+++ b/docs/BUILD_LINUX.md
@@ -1,0 +1,44 @@
+# Build for Linux
+
+1. First, execute all steps in the [How to compile](https://github.com/paulocoutinhox/pdfium-lib/tree/master?tab=readme-ov-file#how-to-compile) section
+
+2. Get PDFium:
+```python3 make.py build-pdfium-linux```
+
+3. Patch:
+```python3 make.py patch-linux```
+
+4. Compile:
+```python3 make.py build-linux```
+
+5. Install libraries:
+```python3 make.py install-linux```
+
+6. Test:
+```python3 make.py test-linux```
+
+Obs:
+- The file **make.py** need be executed with python version 3.
+- You need a C++ toolchain installed, on Debian and Ubuntu: `sudo apt-get install build-essential pkg-config`.
+- The library is built against the system C++ runtime, so build it on the oldest distribution you need to support.
+
+# Sample
+
+The sample project is here: `sample`.
+
+The libraries are installed in `build/linux/release`, with one directory per architecture inside `lib`.
+
+# Architectures
+
+Only `x64` is built by default. To add another one, append it to `targets_linux` in `modules/config.py`:
+
+```
+targets_linux = [
+    {"target_os": "linux", "target_cpu": "x64", "pdfium_os": "linux"},
+    {"target_os": "linux", "target_cpu": "arm64", "pdfium_os": "linux"},
+]
+```
+
+Obs:
+- Cross compiling needs a toolchain for the target architecture.
+- A static `arm64` build also needs `use_lld=false` in `modules/common.py`.

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -1,0 +1,47 @@
+# Build for Windows
+
+1. First, execute all steps in the [How to compile](https://github.com/paulocoutinhox/pdfium-lib/tree/master?tab=readme-ov-file#how-to-compile) section
+
+2. Tell depot tools to use your own Visual Studio instead of the internal Google toolchain:
+```
+set DEPOT_TOOLS_WIN_TOOLCHAIN=0
+```
+
+3. Get PDFium:
+```python3 make.py build-pdfium-windows```
+
+4. Patch:
+```python3 make.py patch-windows```
+
+5. Compile:
+```python3 make.py build-windows```
+
+6. Install libraries:
+```python3 make.py install-windows```
+
+7. Test:
+```python3 make.py test-windows```
+
+Obs:
+- The file **make.py** need be executed with python version 3.
+- You need Visual Studio 2022 with the **Desktop development with C++** workload and the Windows SDK.
+- The `DEPOT_TOOLS_WIN_TOOLCHAIN` variable must be set in every terminal used to build.
+
+# Sample
+
+The sample project is here: `sample`.
+
+The libraries are installed in `build/windows/release`, with one directory per architecture inside `lib`.
+
+# Architectures
+
+Only `x64` is built by default. To add another one, append it to `targets_windows` in `modules/config.py`:
+
+```
+targets_windows = [
+    {"target_os": "windows", "target_cpu": "x64", "pdfium_os": "win"},
+    {"target_os": "windows", "target_cpu": "arm64", "pdfium_os": "win"},
+]
+```
+
+Obs: `arm64` needs the ARM64 build tools installed in Visual Studio.

--- a/extras/wasm/template/index.html
+++ b/extras/wasm/template/index.html
@@ -25,7 +25,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css">
 
     <script>
-        // apply the saved theme before paint to avoid a flash of the wrong scheme
+        // The saved theme is applied before paint to avoid a flash of the wrong scheme.
         (function () {
             const saved = localStorage.getItem('pdfviewer-theme');
 
@@ -61,7 +61,7 @@
             height: 100%;
         }
 
-        /* start screen */
+        /* Start screen. */
         #startScreen {
             position: relative;
             flex: 1;
@@ -106,7 +106,7 @@
             object-fit: contain;
         }
 
-        /* viewer */
+        /* Viewer. */
         #viewer {
             flex: 1;
             display: none;
@@ -133,7 +133,7 @@
             gap: .3rem;
         }
 
-        /* left and right grow equally so the page indicator stays centered */
+        /* Left and right grow equally so the page indicator stays centered. */
         .toolbar-left {
             flex: 1 1 0;
             min-width: 0;
@@ -271,7 +271,7 @@
             }
         }
 
-        /* overlay */
+        /* Loading overlay. */
         #loadingOverlay {
             position: fixed;
             inset: 0;
@@ -290,7 +290,7 @@
             pointer-events: none;
         }
 
-        /* drag overlay */
+        /* Drag overlay. */
         #dropOverlay {
             position: fixed;
             inset: 0;
@@ -315,7 +315,7 @@
             text-align: center;
         }
 
-        /* toast */
+        /* Toast. */
         #toast {
             position: fixed;
             left: 50%;
@@ -332,7 +332,7 @@
             transform: translateX(-50%) translateY(0);
         }
 
-        /* debug console */
+        /* Debug console. */
         #debugConsole {
             position: fixed;
             right: 1rem;
@@ -379,7 +379,7 @@
 
 <body>
     <div id="app">
-        <!-- start screen -->
+        <!-- Start screen. -->
         <section id="startScreen">
             <div class="theme-switch buttons has-addons">
                 <button data-theme-choice="system" class="button is-small" title="Follow system theme">System</button>
@@ -416,7 +416,7 @@
             </div>
         </section>
 
-        <!-- viewer -->
+        <!-- Viewer. -->
         <section id="viewer">
             <div id="toolbar">
                 <div class="toolbar-left">
@@ -455,13 +455,13 @@
         </section>
     </div>
 
-    <!-- loading overlay -->
+    <!-- Loading overlay. -->
     <div id="loadingOverlay">
         <div class="page-spinner"></div>
         <p id="loadingText" class="has-text-grey">Loading engine…</p>
     </div>
 
-    <!-- drag overlay -->
+    <!-- Drag overlay. -->
     <div id="dropOverlay">
         <div class="drop-hint">
             <img class="dropzone-logo" src="logo.png?v={pdfium-branch}" alt="PDF Viewer">
@@ -469,21 +469,20 @@
         </div>
     </div>
 
-    <!-- toast -->
+    <!-- Toast. -->
     <div id="toast" class="notification is-danger"></div>
 
-    <!-- debug console -->
+    <!-- Debug console. -->
     <div id="debugConsole" class="box">
         <p class="has-text-weight-bold mb-2">Debug console</p>
         <div id="debugConsoleContent"></div>
     </div>
 
     <script>
-        // the engine version, replaced at build time, busts the cache of the worker and
-        // of every asset it loads whenever a new release is published
+        // The engine version is replaced at build time and busts the cache of the worker and of every asset it loads.
         const PDFIUM_VERSION = "{pdfium-branch}";
 
-        // viewer tuning
+        // Viewer tuning.
         const MIN_ZOOM = 0.25;
         const MAX_ZOOM = 5.0;
         const ZOOM_STEP = 0.2;
@@ -495,27 +494,27 @@
 
         let worker = null;
 
-        // document holds the page geometry and the source blob, never the pdfium handles
+        // The document holds the page geometry and the source blob, never the pdfium handles.
         let activeDocument = null;
         let zoom = 1.0;
         let fitMode = true;
         let currentPage = 1;
         let scrollRaf = null;
 
-        // renders in flight are tagged with a generation so a zoom can invalidate them
+        // Renders in flight are tagged with a generation so that a zoom can invalidate them.
         let generation = 0;
         let openRequest = null;
 
-        // cheap previews are kept for the whole document, full renders only while on screen
+        // Previews are kept for the whole document, while full renders live only while on screen.
         const previewCache = new Map();
         const requestedPreviews = new Set();
         const requestedFull = new Map();
         const fullPages = new Set();
 
-        // dom references
+        // Dom references.
         const dom = {};
 
-        // resolves once the wasm engine is ready to accept calls
+        // Resolves once the wasm engine is ready to accept calls.
         let markEngineReady;
         const engineReady = new Promise((resolve) => { markEngineReady = resolve; });
 
@@ -556,7 +555,7 @@
             }
         }
 
-        // the buffer moves to the worker, the blob stays here so downloads cost no extra memory
+        // Opens a document, moving the buffer to the worker and keeping the blob here so downloads cost no extra memory.
         function openDocument(buffer, name, blob) {
             return new Promise((resolve, reject) => {
                 closeDocument();
@@ -583,7 +582,7 @@
 
             log('Opened "' + request.name + '" with ' + message.pageCount + ' page(s)');
 
-            // show the viewer first so the container has a real width to measure against
+            // The viewer is shown first so that the container has a real width to measure against.
             showViewer(request.name, message.pageCount);
             buildPages();
             fitWidth();
@@ -594,7 +593,7 @@
         function onDocumentFailed(message) {
             const request = openRequest;
 
-            // ask for a password when the document is protected, reusing the bytes the worker holds
+            // A protected document is retried with a password, reusing the bytes the worker holds.
             if (message.needsPassword) {
                 const entered = window.prompt("This PDF is password protected. Enter the password:");
 
@@ -633,16 +632,16 @@
             generation++;
         }
 
-        // the scale a page is rendered at, capped so huge pages never blow up the bitmap
+        // Returns the scale a page is rendered at, capped so that huge pages never blow up the bitmap.
         function renderScale(size) {
             return Math.min(zoom * PIXEL_RATIO, MAX_PIXEL_DIMENSION / Math.max(size.width, size.height));
         }
 
-        // build placeholder elements sized by page aspect ratio without rendering yet
+        // Builds one placeholder per page, sized by its aspect ratio and not rendered yet.
         function buildPages() {
             dom.pagesContainer.innerHTML = "";
 
-            // a new document always starts at the top, never the previous scroll position
+            // A new document always starts at the top, never at the previous scroll position.
             dom.pagesContainer.scrollTop = 0;
             currentPage = 1;
 
@@ -670,7 +669,7 @@
             page.style.height = Math.round(size.height * zoom) + "px";
         }
 
-        // decide which pages to request and which to drop back to a preview
+        // Requests the pages near the viewport and drops the others back to a preview.
         function refreshVisiblePages() {
             const container = dom.pagesContainer;
             const margin = container.clientHeight * RENDER_MARGIN_RATIO;
@@ -692,14 +691,14 @@
             updateCurrentPage();
         }
 
-        // ask for a coarse preview once, then the sharp render for the current zoom
+        // Requests a coarse preview once, then the sharp render for the current zoom.
         function requestPage(index, priority) {
             const size = activeDocument.sizes[index];
             const scale = renderScale(size);
             const previewScale = Math.min(scale, PREVIEW_MAX_WIDTH / size.width);
 
             if (requestedPreviews.has(index)) {
-                // a page on screen is in use, so it must not be the next preview evicted
+                // A page on screen is in use, so it must not be the next preview evicted.
                 touchPreview(index);
             } else {
                 requestedPreviews.add(index);
@@ -715,7 +714,7 @@
         function onPageRendered(message) {
             const image = toPaintable(message);
 
-            // a render that finished after a zoom or a close is no longer wanted
+            // A render that finished after a zoom or a close is no longer wanted.
             if (message.gen < generation || !activeDocument) {
                 releasePaintable(image);
                 return;
@@ -731,7 +730,7 @@
             if (message.quality === 'preview') {
                 cachePreview(message.index, image);
 
-                // a sharp render already on screen must not be replaced by the preview
+                // A sharp render already on screen must not be replaced by the preview.
                 if (!fullPages.has(message.index)) {
                     paint(page, image, false);
                 }
@@ -739,8 +738,7 @@
                 return;
             }
 
-            // the page may have scrolled out of range while this render was in flight,
-            // in which case releasePage already dropped the request and we throw it away
+            // The page may have scrolled out of range while this render was in flight, and releasePage already dropped the request.
             if (requestedFull.get(message.index) !== message.scale) {
                 releasePaintable(image);
                 return;
@@ -750,7 +748,7 @@
             fullPages.add(message.index);
         }
 
-        // previews are small but a long document still adds up, so keep the recent ones only
+        // Caches a preview, keeping only the most recently used ones since a long document adds up.
         function cachePreview(index, image) {
             releasePaintable(previewCache.get(index));
             previewCache.delete(index);
@@ -765,7 +763,7 @@
             }
         }
 
-        // re-inserting moves the entry to the end, which is what keeps the eviction order honest
+        // Marks a preview as recently used, by moving its entry to the end.
         function touchPreview(index) {
             const image = previewCache.get(index);
 
@@ -793,8 +791,8 @@
             }
         }
 
-        // consume hands the bitmap straight to the canvas without a copy, which empties it,
-        // so only one-shot full renders do it and cached previews are drawn instead
+        // Paints an image into a page, where consume hands the bitmap to the canvas without a copy and empties it.
+        // Only one shot full renders consume, while cached previews are drawn.
         function paint(page, image, consume) {
             const canvas = document.createElement('canvas');
 
@@ -815,11 +813,11 @@
             page.replaceChildren(canvas);
         }
 
-        // scrolling away drops the sharp render but keeps the preview on screen
+        // Drops the sharp render of a page and leaves its preview on screen.
         function releasePage(page, index) {
             const hadFull = fullPages.delete(index);
 
-            // a render still queued for a page nobody is looking at is wasted work
+            // A render still queued for a page nobody is looking at is wasted work.
             if (requestedFull.delete(index)) {
                 worker.postMessage({ type: 'drop', index });
             }
@@ -837,7 +835,7 @@
             }
         }
 
-        // find the page closest to the viewport center for the page indicator
+        // Points the page indicator at the page closest to the viewport center.
         function updateCurrentPage() {
             const container = dom.pagesContainer;
             const center = container.scrollTop + container.clientHeight / 2;
@@ -870,9 +868,8 @@
             }
         }
 
-        // re-layout every page when the zoom changes and re-render what is visible.
-        // the canvases already on screen are left in place and stretched by css, so the
-        // page never flashes back to a spinner while the sharper render is on its way
+        // Applies a zoom, laying every page out again and re-rendering what is visible.
+        // The canvases already on screen are left in place and stretched by css, so a page never flashes back to a spinner.
         function applyZoom(nextZoom) {
             zoom = Math.min(Math.max(nextZoom, MIN_ZOOM), MAX_ZOOM);
             dom.zoomLevel.textContent = Math.round(zoom * 100) + "%";
@@ -881,7 +878,7 @@
                 applyPageSize(page, activeDocument.sizes[Number(page.dataset.index)]);
             }
 
-            // drop everything still queued at the old scale before asking for the new one
+            // Everything still queued at the old scale is dropped before the new one is requested.
             generation++;
             requestedFull.clear();
             worker.postMessage({ type: 'cancel', gen: generation });
@@ -889,13 +886,13 @@
             refreshVisiblePages();
         }
 
-        // manual zoom from the user, which turns off automatic width fitting
+        // Applies a zoom asked by the user, which turns off automatic width fitting.
         function setZoom(nextZoom) {
             fitMode = false;
             applyZoom(nextZoom);
         }
 
-        // fit to the widest page so mixed-size documents never overflow horizontally
+        // Fits the widest page, so that a document of mixed sizes never overflows horizontally.
         function fitWidth() {
             const available = dom.pagesContainer.clientWidth - 24;
 
@@ -909,7 +906,7 @@
             applyZoom(available / widest);
         }
 
-        // file sources
+        // File sources.
         async function openFromFile(file) {
             try {
                 setLoading(true, "Reading file…");
@@ -962,7 +959,7 @@
             URL.revokeObjectURL(link.href);
         }
 
-        // ui state
+        // Interface state.
         function showViewer(name, pageCount) {
             dom.fileTitle.textContent = name;
             dom.pageCount.textContent = String(pageCount);
@@ -1015,14 +1012,14 @@
             dom.debugConsoleContent.prepend(line);
         }
 
-        // wiring
+        // Binds every event.
         function bindEvents() {
             dom.dropzone.onclick = () => dom.fileInput.click();
 
             dom.fileInput.onchange = () => {
                 const file = dom.fileInput.files[0];
 
-                // reset so picking the same file again still fires the change event
+                // The value is reset so that picking the same file again still fires the change event.
                 dom.fileInput.value = "";
 
                 if (file) {
@@ -1051,7 +1048,7 @@
 
             dom.pagesContainer.onscroll = onScroll;
 
-            // ctrl + wheel zooms, like a native viewer
+            // Ctrl and wheel zoom together, like a native viewer.
             dom.pagesContainer.addEventListener('wheel', (event) => {
                 if (event.ctrlKey) {
                     event.preventDefault();
@@ -1059,7 +1056,7 @@
                 }
             }, { passive: false });
 
-            // keep fitting to width on resize and rotation unless the user zoomed manually
+            // Resizing and rotating keep fitting to width, unless the user zoomed manually.
             window.onresize = () => {
                 if (!activeDocument) {
                     return;
@@ -1105,7 +1102,7 @@
             }
         }
 
-        // accept a dropped pdf anywhere on the window, even while a document is open
+        // Accepts a pdf dropped anywhere on the window, even while a document is open.
         function bindDragAndDrop() {
             const stop = (event) => {
                 event.preventDefault();
@@ -1114,7 +1111,7 @@
 
             const hasFiles = (event) => Array.from(event.dataTransfer?.types || []).includes('Files');
 
-            // a counter keeps the overlay stable across nested dragenter and dragleave events
+            // A counter keeps the overlay stable across nested dragenter and dragleave events.
             let dragDepth = 0;
 
             window.addEventListener('dragenter', (event) => {
@@ -1161,7 +1158,7 @@
             });
         }
 
-        // theme: "system" follows prefers-color-scheme, "light" and "dark" force a scheme
+        // Applies a theme, where system follows prefers-color-scheme while light and dark force one.
         function applyTheme(choice) {
             if (choice === 'system') {
                 document.documentElement.removeAttribute('data-theme');
@@ -1190,7 +1187,7 @@
             return new URLSearchParams(window.location.search).get(name);
         }
 
-        // apply optional url parameters: url, title, debug
+        // Applies the optional url parameters, which are url, title and debug.
         function applyUrlParams() {
             const url = getUrlParam("url");
             const title = getUrlParam("title");
@@ -1232,11 +1229,11 @@
             applyUrlParams();
         }
 
-        // the script runs at the end of the body, so the dom is already available
+        // The script runs at the end of the body, so the dom is already available.
         init();
     </script>
 
-    <!-- google analytics -->
+    <!-- Google analytics. -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-J2FWK7KZMQ"></script>
     <script>
         window.dataLayer = window.dataLayer || [];

--- a/extras/wasm/template/pdfium-worker.js
+++ b/extras/wasm/template/pdfium-worker.js
@@ -1,6 +1,5 @@
-// pdfium runs here so that rendering never blocks the ui thread.
-// the version comes from the worker url and is forwarded to every asset it loads,
-// so publishing a new release busts the cache of the worker and of the engine together.
+// Rendering happens here so that it never blocks the ui thread.
+// The version comes from the worker url and is forwarded to every asset it loads, so a new release busts the cache of the worker and of the engine together.
 const VERSION = new URLSearchParams(self.location.search).get('v') || "";
 const VERSION_QUERY = VERSION ? "?v=" + encodeURIComponent(VERSION) : "";
 
@@ -23,18 +22,18 @@ const LAST_ERROR = {
 
 const PASSWORD_ERROR = 4;
 
-// BGRx, not BGRA: an alpha destination makes blend modes composite against the white fill
+// The destination is BGRx and not BGRA, because an alpha destination makes blend modes composite against the white fill.
 const BITMAP_BGRX = 3;
 const BYTES_PER_PIXEL = 4;
 
 let Module = null;
 const FPDF = {};
 
-// the bytes of the last open attempt, kept so a password retry does not resend them
+// The bytes of the last open attempt, kept so a password retry does not resend them.
 let sourceBytes = null;
 let activeDocument = null;
 
-// jobs waiting to be rendered, plus the generation that decides which ones are still wanted
+// The jobs waiting to be rendered, and the generation that decides which ones are still wanted.
 let queue = [];
 let generation = 0;
 let drainScheduled = false;
@@ -88,7 +87,7 @@ self.onmessage = (event) => {
     }
 };
 
-// streaming loader: pdfium reads only the blocks it needs from the source bytes
+// Opens a document, letting pdfium read only the blocks it needs from the source bytes.
 function open(message) {
     closeDocument();
 
@@ -101,7 +100,7 @@ function open(message) {
         return;
     }
 
-    // pdfium keeps calling this while the document is open, so the bytes must outlive it
+    // The bytes have to outlive the call, because pdfium keeps reading them while the document is open.
     const bytes = sourceBytes;
 
     const readBlock = (param, position, bufferPtr, size) => {
@@ -111,7 +110,7 @@ function open(message) {
 
     const readerPtr = Module.addFunction(readBlock, 'iiiii');
 
-    // build the FPDF_FILEACCESS struct: m_FileLen, m_GetBlock, m_Param
+    // Builds the FPDF_FILEACCESS struct, holding m_FileLen, m_GetBlock and m_Param.
     const fileAccessPtr = Module.wasmExports.malloc(12);
     Module.setValue(fileAccessPtr + 0, bytes.length, 'i32');
     Module.setValue(fileAccessPtr + 4, readerPtr, 'i32');
@@ -119,7 +118,7 @@ function open(message) {
 
     const handle = FPDF.LoadCustomDocument(fileAccessPtr, message.password || "");
 
-    // the struct is no longer needed once the document is created
+    // The struct is no longer needed once the document is created.
     Module.wasmExports.free(fileAccessPtr);
 
     if (!handle) {
@@ -138,7 +137,7 @@ function open(message) {
 
     const pageCount = FPDF.GetPageCount(handle);
 
-    // reject documents that opened but carry no pages
+    // Rejects a document that opened but carries no pages.
     if (pageCount <= 0) {
         FPDF.CloseDocument(handle);
         Module.removeFunction(readerPtr);
@@ -167,7 +166,7 @@ function closeDocument() {
     activeDocument = null;
 }
 
-// page sizes are cheap and do not require loading the pages themselves
+// Returns the size of every page, without loading the pages themselves.
 function readPageSizes(handle, pageCount) {
     const widthPtr = Module.wasmExports.malloc(8);
     const heightPtr = Module.wasmExports.malloc(8);
@@ -176,7 +175,7 @@ function readPageSizes(handle, pageCount) {
     for (let index = 0; index < pageCount; index++) {
         FPDF.GetPageSizeByIndex(handle, index, widthPtr, heightPtr);
 
-        // read the doubles straight from the heap, malloc keeps them 8-byte aligned
+        // The doubles are read straight from the heap, which malloc keeps 8 byte aligned.
         sizes.push({
             width: Module.HEAPF64[widthPtr >> 3],
             height: Module.HEAPF64[heightPtr >> 3],
@@ -189,7 +188,7 @@ function readPageSizes(handle, pageCount) {
     return sizes;
 }
 
-// a newer request for the same page and quality replaces the one still waiting
+// Queues a render, replacing any request still waiting for the same page and quality.
 function enqueue(job) {
     if (job.gen > generation) {
         generation = job.gen;
@@ -207,12 +206,12 @@ function scheduleDrain() {
 
     drainScheduled = true;
 
-    // a macrotask, not a microtask: it lets pending messages land between two renders,
-    // which is what makes cancelling a fast scroll or a zoom actually take effect
+    // A macrotask is used instead of a microtask so that pending messages land between two renders.
+    // That is what makes cancelling a fast scroll or a zoom take effect.
     setTimeout(drain, 0);
 }
 
-// pick the most useful job: previews before full renders, then closest to the viewport
+// Returns the most useful job, taking previews before full renders and then the closest to the viewport.
 function takeNext() {
     let best = -1;
 
@@ -261,7 +260,7 @@ async function drain() {
         const image = renderPage(job);
         const payload = { type: 'rendered', index: job.index, quality: job.quality, gen: job.gen, scale: job.scale, width: image.width, height: image.height };
 
-        // an ImageBitmap transfers without a copy and paints without touching the cpu
+        // An ImageBitmap transfers without a copy and paints without touching the cpu.
         if (typeof createImageBitmap === 'function') {
             const bitmap = await createImageBitmap(image);
             self.postMessage({ ...payload, bitmap }, [bitmap]);
@@ -295,7 +294,7 @@ function renderPage(job) {
     FPDF.Bitmap_FillRect(bitmap, 0, 0, width, height, 0xFFFFFFFF);
     FPDF.RenderPageBitmap(bitmap, page, 0, 0, width, height, 0, FPDF_FLAGS.REVERSE_BYTE_ORDER | FPDF_FLAGS.ANNOT);
 
-    // copy pixels out of the heap before releasing the native buffer
+    // The pixels are copied out of the heap before the native buffer is released.
     const pixels = new Uint8ClampedArray(Module.HEAPU8.buffer, bufferPtr, byteCount).slice();
 
     FPDF.Bitmap_Destroy(bitmap);

--- a/make.py
+++ b/make.py
@@ -85,7 +85,7 @@ import modules.windows as windows
 
 
 def main(options):
-    # show all params for debug
+    # Shows every option received when debug is on.
     if ("--debug" in options and options["--debug"]) or (
         "-d" in options and options["-d"]
     ):
@@ -96,227 +96,227 @@ def main(options):
         l.m(str(options))
         l.nl()
 
-    # bind options
+    # Reads the task name from the options.
     if "<task-name>" in options:
         task = options["<task-name>"]
 
-    # validate task
+    # Rejects an empty task name.
     if not task:
         l.e("Task is invalid. Use 'python3 make.py -h' for help.")
 
     #######################
-    # Common
+    # Common tasks.
     #######################
 
-    # format
+    # Formats the source files.
     if task == "format":
         common.run_task_format()
 
-    # build depot tools
+    # Clones the depot tools.
     elif task == "build-depot-tools":
         common.run_task_build_depot_tools()
 
-    # build emsdk
+    # Installs the Emscripten SDK.
     elif task == "build-emsdk":
         common.run_task_build_emsdk()
 
     #######################
-    # iOS
+    # Tasks for iOS.
     #######################
 
-    # build pdfium - ios
+    # Clones and syncs pdfium for iOS.
     elif task == "build-pdfium-ios":
         ios.run_task_build_pdfium()
 
-    # patch - ios
+    # Patches the iOS checkout.
     elif task == "patch-ios":
         ios.run_task_patch()
 
-    # build - ios
+    # Builds the iOS libraries.
     elif task == "build-ios":
         ios.run_task_build()
 
-    # install - ios
+    # Stages the iOS libraries.
     elif task == "install-ios":
         ios.run_task_install()
 
-    # test - ios
+    # Tests the iOS libraries.
     elif task == "test-ios":
         ios.run_task_test()
 
-    # archive - ios
+    # Archives the iOS libraries.
     elif task == "archive-ios":
         ios.run_task_archive()
 
     #######################
-    # macOS
+    # Tasks for macOS.
     #######################
 
-    # build pdfium - macos
+    # Clones and syncs pdfium for macOS.
     elif task == "build-pdfium-macos":
         macos.run_task_build_pdfium()
 
-    # patch - macos
+    # Patches the macOS checkout.
     elif task == "patch-macos":
         macos.run_task_patch()
 
-    # build - macos
+    # Builds the macOS libraries.
     elif task == "build-macos":
         macos.run_task_build()
 
-    # install - macos
+    # Stages the macOS libraries.
     elif task == "install-macos":
         macos.run_task_install()
 
-    # test - macos
+    # Tests the macOS libraries.
     elif task == "test-macos":
         macos.run_task_test()
 
-    # archive - macos
+    # Archives the macOS libraries.
     elif task == "archive-macos":
         macos.run_task_archive()
 
     #######################
-    # Linux
+    # Tasks for Linux.
     #######################
 
-    # build pdfium - linux
+    # Clones and syncs pdfium for Linux.
     elif task == "build-pdfium-linux":
         linux.run_task_build_pdfium()
 
-    # patch - linux
+    # Patches the Linux checkout.
     elif task == "patch-linux":
         linux.run_task_patch()
 
-    # build - linux
+    # Builds the Linux libraries.
     elif task == "build-linux":
         linux.run_task_build()
 
-    # install - linux
+    # Stages the Linux libraries.
     elif task == "install-linux":
         linux.run_task_install()
 
-    # test - linux
+    # Tests the Linux libraries.
     elif task == "test-linux":
         linux.run_task_test()
 
-    # archive - linux
+    # Archives the Linux libraries.
     elif task == "archive-linux":
         linux.run_task_archive()
 
     #######################
-    # Windows
+    # Tasks for Windows.
     #######################
 
-    # build pdfium - windows
+    # Clones and syncs pdfium for Windows.
     elif task == "build-pdfium-windows":
         windows.run_task_build_pdfium()
 
-    # patch - windows
+    # Patches the Windows checkout.
     elif task == "patch-windows":
         windows.run_task_patch()
 
-    # build - windows
+    # Builds the Windows libraries.
     elif task == "build-windows":
         windows.run_task_build()
 
-    # install - windows
+    # Stages the Windows libraries.
     elif task == "install-windows":
         windows.run_task_install()
 
-    # test - windows
+    # Tests the Windows libraries.
     elif task == "test-windows":
         windows.run_task_test()
 
-    # archive - windows
+    # Archives the Windows libraries.
     elif task == "archive-windows":
         windows.run_task_archive()
 
     #######################
-    # Android
+    # Tasks for Android.
     #######################
 
-    # build pdfium - android
+    # Clones and syncs pdfium for Android.
     elif task == "build-pdfium-android":
         android.run_task_build_pdfium()
 
-    # patch - android
+    # Patches the Android checkout.
     elif task == "patch-android":
         android.run_task_patch()
 
-    # build - android
+    # Builds the Android libraries.
     elif task == "build-android":
         android.run_task_build()
 
-    # install - android
+    # Stages the Android libraries.
     elif task == "install-android":
         android.run_task_install()
 
-    # test - android
+    # Tests the Android libraries.
     elif task == "test-android":
         android.run_task_test()
 
-    # archive - android
+    # Archives the Android libraries.
     elif task == "archive-android":
         android.run_task_archive()
 
     #######################
-    # WASM
+    # Tasks for WASM.
     #######################
 
-    # build pdfium - wasm
+    # Clones and syncs pdfium for WASM.
     elif task == "build-pdfium-wasm":
         wasm.run_task_build_pdfium()
 
-    # patch - wasm
+    # Patches the WASM checkout.
     elif task == "patch-wasm":
         wasm.run_task_patch()
 
-    # build - wasm
+    # Builds the WASM libraries.
     elif task == "build-wasm":
         wasm.run_task_build()
 
-    # install - wasm
+    # Stages the WASM libraries.
     elif task == "install-wasm":
         wasm.run_task_install()
 
-    # test - wasm
+    # Tests the WASM libraries.
     elif task == "test-wasm":
         wasm.run_task_test()
 
-    # test - wasmtime
+    # Tests the WASM libraries with wasmtime.
     elif task == "test-wasmtime":
         wasm.run_task_test_wasmtime()
 
-    # generate - wasm
+    # Generates the WASM package.
     elif task == "generate-wasm":
         wasm.run_task_generate()
 
-    # publish - wasm
+    # Publishes the WASM package.
     elif task == "publish-wasm":
         wasm.run_task_publish()
 
-    # publish to web - wasm
+    # Publishes the WASM package to the web.
     elif task == "publish-to-web-wasm":
         wasm.run_task_publish_to_web()
 
-    # archive - wasm
+    # Archives the WASM libraries.
     elif task == "archive-wasm":
         wasm.run_task_archive()
 
     #######################
-    # Invalid
+    # Unknown task.
     #######################
 
-    # invalid
+    # Reports an unknown task.
     else:
         l.e("Task is invalid")
 
 
 if __name__ == "__main__":
-    # initialization
+    # Initializes the environment.
     b.init()
 
-    # main CLI entrypoint
+    # Runs the command line interface.
     args = docopt(__doc__, version="2.0.0")
     main(args)

--- a/make.py
+++ b/make.py
@@ -37,6 +37,20 @@ Tasks:
   - test-macos
   - archive-macos
 
+  - build-pdfium-linux
+  - patch-linux
+  - build-linux
+  - install-linux
+  - test-linux
+  - archive-linux
+
+  - build-pdfium-windows
+  - patch-windows
+  - build-windows
+  - install-windows
+  - test-windows
+  - archive-windows
+
   - build-pdfium-android
   - patch-android
   - build-android
@@ -64,8 +78,10 @@ import modules.android as android
 import modules.common as common
 import modules.config as c
 import modules.ios as ios
+import modules.linux as linux
 import modules.macos as macos
 import modules.wasm as wasm
+import modules.windows as windows
 
 
 def main(options):
@@ -159,6 +175,62 @@ def main(options):
     # archive - macos
     elif task == "archive-macos":
         macos.run_task_archive()
+
+    #######################
+    # Linux
+    #######################
+
+    # build pdfium - linux
+    elif task == "build-pdfium-linux":
+        linux.run_task_build_pdfium()
+
+    # patch - linux
+    elif task == "patch-linux":
+        linux.run_task_patch()
+
+    # build - linux
+    elif task == "build-linux":
+        linux.run_task_build()
+
+    # install - linux
+    elif task == "install-linux":
+        linux.run_task_install()
+
+    # test - linux
+    elif task == "test-linux":
+        linux.run_task_test()
+
+    # archive - linux
+    elif task == "archive-linux":
+        linux.run_task_archive()
+
+    #######################
+    # Windows
+    #######################
+
+    # build pdfium - windows
+    elif task == "build-pdfium-windows":
+        windows.run_task_build_pdfium()
+
+    # patch - windows
+    elif task == "patch-windows":
+        windows.run_task_patch()
+
+    # build - windows
+    elif task == "build-windows":
+        windows.run_task_build()
+
+    # install - windows
+    elif task == "install-windows":
+        windows.run_task_install()
+
+    # test - windows
+    elif task == "test-windows":
+        windows.run_task_test()
+
+    # archive - windows
+    elif task == "archive-windows":
+        windows.run_task_archive()
 
     #######################
     # Android

--- a/modules/android.py
+++ b/modules/android.py
@@ -22,15 +22,15 @@ def run_task_patch():
 
     source_dir = os.path.join("build", "android", "pdfium")
 
-    # shared lib
+    # Turns the library target into a shared one.
     if c.shared_lib_android:
         patch.apply_shared_library("android")
 
-    # public headers
+    # Removes the component build guards from the public headers.
     if c.shared_lib_android:
         patch.apply_public_headers("android")
 
-    # build config
+    # Adjusts the build configuration for Android.
     source_file = os.path.join(
         source_dir,
         "build",
@@ -57,9 +57,9 @@ def run_task_build():
 
     current_dir = f.current_dir()
 
-    # configs
+    # Walks every configuration.
     for config in c.configurations_android:
-        # targets
+        # Walks every target.
         for target in c.targets_android:
             main_dir = os.path.join(
                 "build",
@@ -79,7 +79,7 @@ def run_task_build():
                 )
             )
 
-            # generating files...
+            # Generates the ninja files.
             l.colored(
                 'Generating files to arch "{0}" and configuration "{1}"...'.format(
                     target["target_cpu"], config
@@ -106,7 +106,7 @@ def run_task_build():
             ]
             r.run(" ".join(command), shell=True)
 
-            # compiling...
+            # Compiles the library.
             l.colored(
                 'Compiling to arch "{0}" and configuration "{1}"...'.format(
                     target["target_cpu"], config
@@ -134,11 +134,11 @@ def run_task_build():
 def run_task_install():
     l.colored("Installing libraries...", l.YELLOW)
 
-    # configs
+    # Walks every configuration.
     for config in c.configurations_android:
         f.recreate_dir(os.path.join("build", "android", config))
 
-        # targets
+        # Walks every target.
         for target in c.targets_android:
             out_dir = "{0}-{1}-{2}".format(
                 target["target_os"], target["target_cpu"], config
@@ -158,7 +158,7 @@ def run_task_install():
                     if os.path.isfile(pathname):
                         f.copy_file(pathname, os.path.join(target_dir, basename))
 
-            # fix include path
+            # Rewrites the public includes so they resolve outside the checkout.
             source_include_path = os.path.join(
                 "build",
                 target["target_os"],
@@ -171,7 +171,7 @@ def run_task_install():
             for header in headers:
                 f.replace_in_file(header, '#include "public/', '#include "../')
 
-        # headers
+        # Copies the public headers.
         l.colored("Copying header files...", l.YELLOW)
 
         include_dir = os.path.join("build", "android", "pdfium", "public")

--- a/modules/common.py
+++ b/modules/common.py
@@ -158,22 +158,18 @@ def get_build_args(
         args.append("clang_use_chrome_plugins=false")
         args.append("pdf_is_standalone=true")
 
-        # the bundled libc++ is never linked into a static_library and its symbols
-        # carry the __Cr abi namespace, so the consumer would fail on undefined
-        # std::__Cr symbols. build against the system c++ runtime instead
+        # The bundled libc++ never reaches a static library and its symbols carry the __Cr ABI namespace, which no system runtime provides.
         args.append("use_custom_libcxx=false")
 
-        # building against the host toolchain avoids depending on the chromium
-        # sysroot, which is not installed by a minimal checkout
+        # The chromium sysroot is not installed by a minimal checkout, so build against the host toolchain.
         args.append("use_sysroot=false")
 
         # static lib
         if not shared:
             args.append("pdf_is_complete_lib=true")
 
-            # lld makes the compiler emit crel relocations, which only binutils
-            # 2.44 and newer can read. the archive we ship has to link with the
-            # gnu linker people already have, so keep the old relocation format
+            # Enabling lld makes the compiler emit crel relocations, which only binutils 2.44 and newer can read.
+            # The published archive has to link with the GNU linker people already have.
             args.append("use_lld=false")
     elif target_os == "win":
         args.append("clang_use_chrome_plugins=false")

--- a/modules/common.py
+++ b/modules/common.py
@@ -157,6 +157,27 @@ def get_build_args(
     elif target_os == "linux":
         args.append("clang_use_chrome_plugins=false")
         args.append("pdf_is_standalone=true")
+
+        # the bundled libc++ is never linked into a static_library and its symbols
+        # carry the __Cr abi namespace, so the consumer would fail on undefined
+        # std::__Cr symbols. build against the system c++ runtime instead
+        args.append("use_custom_libcxx=false")
+
+        # building against the host toolchain avoids depending on the chromium
+        # sysroot, which is not installed by a minimal checkout
+        args.append("use_sysroot=false")
+
+        # static lib
+        if not shared:
+            args.append("pdf_is_complete_lib=true")
+    elif target_os == "win":
+        args.append("clang_use_chrome_plugins=false")
+        args.append("pdf_is_standalone=true")
+        args.append("use_custom_libcxx=false")
+
+        # static lib
+        if not shared:
+            args.append("pdf_is_complete_lib=true")
     elif target_os.startswith("mac"):
         args.append('mac_deployment_target="11.0.0"')
         args.append("clang_use_chrome_plugins=false")

--- a/modules/common.py
+++ b/modules/common.py
@@ -170,6 +170,11 @@ def get_build_args(
         # static lib
         if not shared:
             args.append("pdf_is_complete_lib=true")
+
+            # lld makes the compiler emit crel relocations, which only binutils
+            # 2.44 and newer can read. the archive we ship has to link with the
+            # gnu linker people already have, so keep the old relocation format
+            args.append("use_lld=false")
     elif target_os == "win":
         args.append("clang_use_chrome_plugins=false")
         args.append("pdf_is_standalone=true")

--- a/modules/common.py
+++ b/modules/common.py
@@ -78,23 +78,22 @@ def run_task_build_emsdk():
 
 # -----------------------------------------------------------------------------
 def run_task_format():
-    # check
+    # Requires black to be installed.
     try:
         subprocess.check_output(["black", "--version"])
     except OSError:
         l.e("Black is not installed, check: https://github.com/psf/black")
 
-    # start
     l.colored("Formating files...", l.YELLOW)
 
-    # make.py
+    # Formats the entry point.
     command = [
         "black",
         "make.py",
     ]
     r.run(command)
 
-    # modules
+    # Formats the modules.
     command = [
         "black",
         "modules/",
@@ -151,7 +150,7 @@ def get_build_args(
             args.append('arm_control_flow_integrity="none"')
         args.append("clang_use_chrome_plugins=false")
 
-        # static lib
+        # A static build needs the complete library.
         if not shared:
             args.append("pdf_is_complete_lib=true")
     elif target_os == "linux":
@@ -164,7 +163,7 @@ def get_build_args(
         # The chromium sysroot is not installed by a minimal checkout, so build against the host toolchain.
         args.append("use_sysroot=false")
 
-        # static lib
+        # A static build needs the complete library.
         if not shared:
             args.append("pdf_is_complete_lib=true")
 
@@ -176,7 +175,7 @@ def get_build_args(
         args.append("pdf_is_standalone=true")
         args.append("use_custom_libcxx=false")
 
-        # static lib
+        # A static build needs the complete library.
         if not shared:
             args.append("pdf_is_complete_lib=true")
     elif target_os.startswith("mac"):
@@ -187,7 +186,7 @@ def get_build_args(
         args.append("use_sysroot=false")
         args.append("use_allocator_shim=false")
 
-        # static lib
+        # A static build needs the complete library.
         if not shared:
             args.append("pdf_is_complete_lib=true")
     elif target_os.startswith("emscripten"):

--- a/modules/config.py
+++ b/modules/config.py
@@ -1,18 +1,17 @@
-# general
+# General settings.
 debug = False
 task = ""
 
-# pdfium
+# PDFium settings.
 pdfium_git_branch = "chromium/8046"
-# ^ ref: https://pdfium.googlesource.com/pdfium/+/refs/heads/chromium/8046
-# OBS 1: don't forget change in android docker file (docker/android/Dockerfile)
-# OBS 2: don't forget change in wasm docker file (docker/wasm/Dockerfile)
+# The branch reference is https://pdfium.googlesource.com/pdfium/+/refs/heads/chromium/8046.
+# Changing it also requires changing docker/android/Dockerfile and docker/wasm/Dockerfile.
 
-# emsdk
+# Emscripten SDK settings.
 emsdk_version = "6.0.0"
-# OBS 1: don't forget change in wasm docker file (docker/wasm/Dockerfile)
+# Changing it also requires changing docker/wasm/Dockerfile.
 
-# macos
+# Settings for macOS.
 configurations_macos = ["release"]
 shared_lib_macos = False
 targets_macos = [
@@ -20,21 +19,21 @@ targets_macos = [
     {"target_os": "macos", "target_cpu": "arm64", "pdfium_os": "mac"},
 ]
 
-# linux
+# Settings for Linux.
 configurations_linux = ["release"]
 shared_lib_linux = False
 targets_linux = [
     {"target_os": "linux", "target_cpu": "x64", "pdfium_os": "linux"},
 ]
 
-# windows
+# Settings for Windows.
 configurations_windows = ["release"]
 shared_lib_windows = False
 targets_windows = [
     {"target_os": "windows", "target_cpu": "x64", "pdfium_os": "win"},
 ]
 
-# ios
+# Settings for iOS.
 configurations_ios = ["release"]
 shared_lib_ios = False
 targets_ios = [
@@ -58,7 +57,7 @@ targets_ios = [
     },
 ]
 
-# android
+# Settings for Android.
 configurations_android = ["release"]
 shared_lib_android = True
 targets_android = [
@@ -88,7 +87,7 @@ targets_android = [
     },
 ]
 
-# wasm
+# Settings for WASM.
 configurations_wasm = ["release"]
 shared_lib_wasm = False
 targets_wasm = [

--- a/modules/config.py
+++ b/modules/config.py
@@ -20,6 +20,20 @@ targets_macos = [
     {"target_os": "macos", "target_cpu": "arm64", "pdfium_os": "mac"},
 ]
 
+# linux
+configurations_linux = ["release"]
+shared_lib_linux = False
+targets_linux = [
+    {"target_os": "linux", "target_cpu": "x64", "pdfium_os": "linux"},
+]
+
+# windows
+configurations_windows = ["release"]
+shared_lib_windows = False
+targets_windows = [
+    {"target_os": "windows", "target_cpu": "x64", "pdfium_os": "win"},
+]
+
 # ios
 configurations_ios = ["release"]
 shared_lib_ios = False

--- a/modules/ios.py
+++ b/modules/ios.py
@@ -23,15 +23,15 @@ def run_task_patch():
 
     source_dir = os.path.join("build", "ios", "pdfium")
 
-    # shared lib
+    # Turns the library target into a shared one.
     if c.shared_lib_ios:
         patch.apply_shared_library("ios")
 
-    # public headers
+    # Removes the component build guards from the public headers.
     if c.shared_lib_ios:
         patch.apply_public_headers("ios")
 
-    # rules - test
+    # Removes the test rules that the standalone build does not need.
     source_file = os.path.join(source_dir, "build", "config", "ios", "rules.gni")
 
     line_content = 'data_deps += [ "//testing/iossim" ]'
@@ -45,7 +45,7 @@ def run_task_patch():
     else:
         l.bullet("Skipped: rules - test", l.PURPLE)
 
-    # core fxge
+    # Adjusts the core fxge target for iOS.
     source_file = os.path.join(source_dir, "core", "fxge", "BUILD.gn")
 
     line_content = "if (is_mac) {"
@@ -60,7 +60,7 @@ def run_task_patch():
     else:
         l.bullet("Skipped: core fxge", l.PURPLE)
 
-    # ios automatically manage certs
+    # Lets Xcode manage the signing certificates automatically.
     source_file = os.path.join(
         source_dir,
         "build",
@@ -90,9 +90,9 @@ def run_task_build():
 
     current_dir = f.current_dir()
 
-    # configs
+    # Walks every configuration.
     for config in c.configurations_ios:
-        # targets
+        # Walks every target.
         for target in c.targets_ios:
             main_dir = os.path.join(
                 "build",
@@ -117,7 +117,7 @@ def run_task_build():
                 )
             )
 
-            # generating files...
+            # Generates the ninja files.
             l.colored(
                 'Generating files to arch "{0}" and configuration "{1}"...'.format(
                     target["target_cpu"], config
@@ -148,7 +148,7 @@ def run_task_build():
             ]
             r.run(" ".join(command), shell=True)
 
-            # compiling...
+            # Compiles the library.
             l.colored(
                 'Compiling to arch "{0}" and configuration "{1}"...'.format(
                     target["target_cpu"], config
@@ -179,12 +179,12 @@ def run_task_build():
 def run_task_install():
     l.colored("Installing libraries...", l.YELLOW)
 
-    # configs
+    # Walks every configuration.
     for config in c.configurations_ios:
         f.recreate_dir(os.path.join("build", "ios", config))
         f.create_dir(os.path.join("build", "ios", config, "lib"))
 
-        # targets
+        # Walks every target.
         for target in c.targets_ios:
             source_lib_path = os.path.join(
                 "build",
@@ -213,7 +213,7 @@ def run_task_install():
 
             f.copy_file(source_lib_path, target_lib_path)
 
-            # fix include path
+            # Rewrites the public includes so they resolve outside the checkout.
             source_include_path = os.path.join(
                 "build",
                 target["target_os"],
@@ -226,7 +226,7 @@ def run_task_install():
             for header in headers:
                 f.replace_in_file(header, '#include "public/', '#include "../')
 
-        # universal
+        # Merges the per architecture libraries into a universal one.
         universal_libs = []
         for env in ["simulator", "device"]:
             folder = os.path.join("build", "ios", config, "lib", "*-{0}.a".format(env))
@@ -251,7 +251,7 @@ def run_task_install():
             command = ["ls", "-lh ", lib_file_out]
             r.run(" ".join(command), shell=True)
 
-        # headers
+        # Copies the public headers.
         l.colored("Copying header files...", l.YELLOW)
 
         include_dir = os.path.join("build", "ios", "pdfium", "public")
@@ -263,7 +263,7 @@ def run_task_install():
         f.copy_files(include_dir, target_include_dir, "*.h")
         f.copy_files(include_cpp_dir, target_include_cpp_dir, "*.h")
 
-        # xcframework
+        # Packs the libraries into an xcframework.
         xcframework_out = os.path.join("build", "ios", config, "pdfium.xcframework")
         command = ["xcodebuild", "-create-xcframework"]
 

--- a/modules/linux.py
+++ b/modules/linux.py
@@ -1,0 +1,242 @@
+import os
+import tarfile
+
+from pygemstones.io import file as f
+from pygemstones.system import runner as r
+from pygemstones.util import log as l
+
+import modules.common as cm
+import modules.config as c
+import modules.patch as patch
+import modules.pdfium as p
+
+
+# -----------------------------------------------------------------------------
+def run_task_build_pdfium():
+    p.get_pdfium_by_target("linux")
+
+
+# -----------------------------------------------------------------------------
+def run_task_patch():
+    l.colored("Patching files...", l.YELLOW)
+
+    # shared lib
+    if c.shared_lib_linux:
+        patch.apply_shared_library("linux")
+
+    # public headers
+    if c.shared_lib_linux:
+        patch.apply_public_headers("linux")
+
+    l.ok()
+
+
+# -----------------------------------------------------------------------------
+def run_task_build():
+    l.colored("Building libraries...", l.YELLOW)
+
+    current_dir = f.current_dir()
+
+    # configs
+    for config in c.configurations_linux:
+        # targets
+        for target in c.targets_linux:
+            main_dir = os.path.join(
+                "build",
+                target["target_os"],
+                "pdfium",
+                "out",
+                "{0}-{1}-{2}".format(target["target_os"], target["target_cpu"], config),
+            )
+
+            f.recreate_dir(main_dir)
+
+            os.chdir(
+                os.path.join(
+                    "build",
+                    target["target_os"],
+                    "pdfium",
+                )
+            )
+
+            # generating files...
+            l.colored(
+                'Generating files to arch "{0}" and configuration "{1}"...'.format(
+                    target["target_cpu"], config
+                ),
+                l.YELLOW,
+            )
+
+            args = cm.get_build_args(
+                config,
+                c.shared_lib_linux,
+                target["pdfium_os"],
+                target["target_cpu"],
+            )
+
+            args_str = " ".join(args)
+
+            command = [
+                "gn",
+                "gen",
+                "out/{0}-{1}-{2}".format(
+                    target["target_os"], target["target_cpu"], config
+                ),
+                "--args='{0}'".format(args_str),
+            ]
+            r.run(" ".join(command), shell=True)
+
+            # compiling...
+            l.colored(
+                'Compiling to arch "{0}" and configuration "{1}"...'.format(
+                    target["target_cpu"], config
+                ),
+                l.YELLOW,
+            )
+
+            command = [
+                "ninja",
+                "-C",
+                "out/{0}-{1}-{2}".format(
+                    target["target_os"], target["target_cpu"], config
+                ),
+                "pdfium",
+                "-v",
+            ]
+            r.run(command)
+
+            os.chdir(current_dir)
+
+    l.ok()
+
+
+# -----------------------------------------------------------------------------
+def run_task_install():
+    l.colored("Installing libraries...", l.YELLOW)
+
+    # configs
+    for config in c.configurations_linux:
+        f.recreate_dir(os.path.join("build", "linux", config))
+        f.create_dir(os.path.join("build", "linux", config, "lib"))
+
+        # targets
+        for target in c.targets_linux:
+            out_dir = os.path.join(
+                "build",
+                target["target_os"],
+                "pdfium",
+                "out",
+                "{0}-{1}-{2}".format(target["target_os"], target["target_cpu"], config),
+            )
+
+            # a shared library lands next to the binaries, a static one under obj
+            if c.shared_lib_linux:
+                lib_file_name = "libpdfium.so"
+                source_lib_path = os.path.join(out_dir, lib_file_name)
+            else:
+                lib_file_name = "libpdfium.a"
+                source_lib_path = os.path.join(out_dir, "obj", lib_file_name)
+
+            # there is no fat binary on linux, so each arch keeps its own directory
+            target_lib_path = os.path.join(
+                "build",
+                target["target_os"],
+                config,
+                "lib",
+                target["target_cpu"],
+                lib_file_name,
+            )
+
+            f.copy_file(source_lib_path, target_lib_path)
+
+            l.colored("File data...", l.YELLOW)
+            command = ["file", target_lib_path]
+            r.run(" ".join(command), shell=True)
+
+            l.colored("File size...", l.YELLOW)
+            command = ["ls", "-lh", target_lib_path]
+            r.run(" ".join(command), shell=True)
+
+            # fix include path
+            source_include_path = os.path.join(
+                "build",
+                target["target_os"],
+                "pdfium",
+                "public",
+            )
+
+            headers = f.find_files(source_include_path, "*.h", True)
+
+            for header in headers:
+                f.replace_in_file(header, '#include "public/', '#include "../')
+
+        # headers
+        l.colored("Copying header files...", l.YELLOW)
+
+        include_dir = os.path.join("build", "linux", "pdfium", "public")
+        include_cpp_dir = os.path.join(include_dir, "cpp")
+        target_include_dir = os.path.join("build", "linux", config, "include")
+        target_include_cpp_dir = os.path.join(target_include_dir, "cpp")
+
+        f.recreate_dir(target_include_dir)
+        f.copy_files(include_dir, target_include_dir, "*.h")
+        f.copy_files(include_cpp_dir, target_include_cpp_dir, "*.h")
+
+    l.ok()
+
+
+# -----------------------------------------------------------------------------
+def run_task_test():
+    l.colored("Testing...", l.YELLOW)
+
+    current_dir = os.getcwd()
+    sample_dir = os.path.join(current_dir, "sample")
+    build_dir = os.path.join(sample_dir, "build")
+
+    f.recreate_dir(build_dir)
+
+    os.chdir(build_dir)
+
+    # generate project
+    command = ["cmake", "../"]
+    r.run(command)
+
+    # build
+    command = ["cmake", "--build", "."]
+    r.run(command)
+
+    # copy assets
+    f.copy_file(
+        os.path.join(sample_dir, "assets", "f1.pdf"),
+        os.path.join(build_dir, "f1.pdf"),
+    )
+
+    # run
+    command = ["./sample"]
+    r.run(command)
+
+    # finish
+    os.chdir(current_dir)
+
+    l.ok()
+
+
+# -----------------------------------------------------------------------------
+def run_task_archive():
+    l.colored("Archiving...", l.YELLOW)
+
+    current_dir = f.current_dir()
+    lib_dir = os.path.join(current_dir, "build", "linux")
+    output_filename = os.path.join(current_dir, "linux.tgz")
+
+    tar = tarfile.open(output_filename, "w:gz")
+
+    for configuration in c.configurations_linux:
+        tar.add(
+            name=os.path.join(lib_dir, configuration),
+            arcname=os.path.basename(os.path.join(lib_dir, configuration)),
+        )
+
+    tar.close()
+
+    l.ok()

--- a/modules/linux.py
+++ b/modules/linux.py
@@ -121,21 +121,15 @@ def run_task_install():
 
         # targets
         for target in c.targets_linux:
-            out_dir = os.path.join(
+            source_lib_path = os.path.join(
                 "build",
                 target["target_os"],
                 "pdfium",
                 "out",
                 "{0}-{1}-{2}".format(target["target_os"], target["target_cpu"], config),
+                "obj",
+                "libpdfium.a",
             )
-
-            # a shared library lands next to the binaries, a static one under obj
-            if c.shared_lib_linux:
-                lib_file_name = "libpdfium.so"
-                source_lib_path = os.path.join(out_dir, lib_file_name)
-            else:
-                lib_file_name = "libpdfium.a"
-                source_lib_path = os.path.join(out_dir, "obj", lib_file_name)
 
             # there is no fat binary on linux, so each arch keeps its own directory
             target_lib_path = os.path.join(
@@ -144,7 +138,7 @@ def run_task_install():
                 config,
                 "lib",
                 target["target_cpu"],
-                lib_file_name,
+                "libpdfium.a",
             )
 
             f.copy_file(source_lib_path, target_lib_path)

--- a/modules/linux.py
+++ b/modules/linux.py
@@ -131,7 +131,6 @@ def run_task_install():
                 "libpdfium.a",
             )
 
-            # there is no fat binary on linux, so each arch keeps its own directory
             target_lib_path = os.path.join(
                 "build",
                 target["target_os"],
@@ -187,30 +186,39 @@ def run_task_test():
     sample_dir = os.path.join(current_dir, "sample")
     build_dir = os.path.join(sample_dir, "build")
 
-    f.recreate_dir(build_dir)
+    # configs
+    for config in c.configurations_linux:
+        f.recreate_dir(build_dir)
 
-    os.chdir(build_dir)
+        os.chdir(build_dir)
 
-    # generate project
-    command = ["cmake", "../"]
-    r.run(command)
+        cmake_config = config.capitalize()
 
-    # build
-    command = ["cmake", "--build", "."]
-    r.run(command)
+        # generate project
+        command = [
+            "cmake",
+            "-DPDFIUM_CONFIG={0}".format(config),
+            "-DCMAKE_BUILD_TYPE={0}".format(cmake_config),
+            "../",
+        ]
+        r.run(command)
 
-    # copy assets
-    f.copy_file(
-        os.path.join(sample_dir, "assets", "f1.pdf"),
-        os.path.join(build_dir, "f1.pdf"),
-    )
+        # build
+        command = ["cmake", "--build", ".", "--config", cmake_config]
+        r.run(command)
 
-    # run
-    command = ["./sample"]
-    r.run(command)
+        # copy assets
+        f.copy_file(
+            os.path.join(sample_dir, "assets", "f1.pdf"),
+            os.path.join(build_dir, "f1.pdf"),
+        )
 
-    # finish
-    os.chdir(current_dir)
+        # run
+        command = ["./sample"]
+        r.run(command)
+
+        # finish
+        os.chdir(current_dir)
 
     l.ok()
 

--- a/modules/linux.py
+++ b/modules/linux.py
@@ -20,11 +20,11 @@ def run_task_build_pdfium():
 def run_task_patch():
     l.colored("Patching files...", l.YELLOW)
 
-    # shared lib
+    # Turns the library target into a shared one.
     if c.shared_lib_linux:
         patch.apply_shared_library("linux")
 
-    # public headers
+    # Removes the component build guards from the public headers.
     if c.shared_lib_linux:
         patch.apply_public_headers("linux")
 
@@ -37,9 +37,9 @@ def run_task_build():
 
     current_dir = f.current_dir()
 
-    # configs
+    # Walks every configuration.
     for config in c.configurations_linux:
-        # targets
+        # Walks every target.
         for target in c.targets_linux:
             main_dir = os.path.join(
                 "build",
@@ -59,7 +59,7 @@ def run_task_build():
                 )
             )
 
-            # generating files...
+            # Generates the ninja files.
             l.colored(
                 'Generating files to arch "{0}" and configuration "{1}"...'.format(
                     target["target_cpu"], config
@@ -86,7 +86,7 @@ def run_task_build():
             ]
             r.run(" ".join(command), shell=True)
 
-            # compiling...
+            # Compiles the library.
             l.colored(
                 'Compiling to arch "{0}" and configuration "{1}"...'.format(
                     target["target_cpu"], config
@@ -114,12 +114,12 @@ def run_task_build():
 def run_task_install():
     l.colored("Installing libraries...", l.YELLOW)
 
-    # configs
+    # Walks every configuration.
     for config in c.configurations_linux:
         f.recreate_dir(os.path.join("build", "linux", config))
         f.create_dir(os.path.join("build", "linux", config, "lib"))
 
-        # targets
+        # Walks every target.
         for target in c.targets_linux:
             source_lib_path = os.path.join(
                 "build",
@@ -150,7 +150,7 @@ def run_task_install():
             command = ["ls", "-lh", target_lib_path]
             r.run(" ".join(command), shell=True)
 
-            # fix include path
+            # Rewrites the public includes so they resolve outside the checkout.
             source_include_path = os.path.join(
                 "build",
                 target["target_os"],
@@ -163,7 +163,7 @@ def run_task_install():
             for header in headers:
                 f.replace_in_file(header, '#include "public/', '#include "../')
 
-        # headers
+        # Copies the public headers.
         l.colored("Copying header files...", l.YELLOW)
 
         include_dir = os.path.join("build", "linux", "pdfium", "public")
@@ -186,7 +186,7 @@ def run_task_test():
     sample_dir = os.path.join(current_dir, "sample")
     build_dir = os.path.join(sample_dir, "build")
 
-    # configs
+    # Walks every configuration.
     for config in c.configurations_linux:
         f.recreate_dir(build_dir)
 
@@ -194,7 +194,7 @@ def run_task_test():
 
         cmake_config = config.capitalize()
 
-        # generate project
+        # Generates the sample project.
         command = [
             "cmake",
             "-DPDFIUM_CONFIG={0}".format(config),
@@ -203,21 +203,21 @@ def run_task_test():
         ]
         r.run(command)
 
-        # build
+        # Builds the sample.
         command = ["cmake", "--build", ".", "--config", cmake_config]
         r.run(command)
 
-        # copy assets
+        # Copies the assets the sample opens.
         f.copy_file(
             os.path.join(sample_dir, "assets", "f1.pdf"),
             os.path.join(build_dir, "f1.pdf"),
         )
 
-        # run
+        # Runs the sample.
         command = ["./sample"]
         r.run(command)
 
-        # finish
+        # Returns to the starting directory.
         os.chdir(current_dir)
 
     l.ok()

--- a/modules/macos.py
+++ b/modules/macos.py
@@ -21,11 +21,11 @@ def run_task_build_pdfium():
 def run_task_patch():
     l.colored("Patching files...", l.YELLOW)
 
-    # shared lib
+    # Turns the library target into a shared one.
     if c.shared_lib_macos:
         patch.apply_shared_library("macos")
 
-    # public headers
+    # Removes the component build guards from the public headers.
     if c.shared_lib_macos:
         patch.apply_public_headers("macos")
 
@@ -38,9 +38,9 @@ def run_task_build():
 
     current_dir = f.current_dir()
 
-    # configs
+    # Walks every configuration.
     for config in c.configurations_macos:
-        # targets
+        # Walks every target.
         for target in c.targets_macos:
             main_dir = os.path.join(
                 "build",
@@ -60,7 +60,7 @@ def run_task_build():
                 )
             )
 
-            # generating files...
+            # Generates the ninja files.
             l.colored(
                 'Generating files to arch "{0}" and configuration "{1}"...'.format(
                     target["target_cpu"], config
@@ -87,7 +87,7 @@ def run_task_build():
             ]
             r.run(" ".join(command), shell=True)
 
-            # compiling...
+            # Compiles the library.
             l.colored(
                 'Compiling to arch "{0}" and configuration "{1}"...'.format(
                     target["target_cpu"], config
@@ -115,12 +115,12 @@ def run_task_build():
 def run_task_install():
     l.colored("Installing libraries...", l.YELLOW)
 
-    # configs
+    # Walks every configuration.
     for config in c.configurations_macos:
         f.recreate_dir(os.path.join("build", "macos", config))
         f.create_dir(os.path.join("build", "macos", config, "lib"))
 
-        # targets
+        # Walks every target.
         for target in c.targets_macos:
             source_lib_path = os.path.join(
                 "build",
@@ -142,7 +142,7 @@ def run_task_install():
 
             f.copy_file(source_lib_path, target_lib_path)
 
-            # fix include path
+            # Rewrites the public includes so they resolve outside the checkout.
             source_include_path = os.path.join(
                 "build",
                 target["target_os"],
@@ -155,7 +155,7 @@ def run_task_install():
             for header in headers:
                 f.replace_in_file(header, '#include "public/', '#include "../')
 
-        # universal
+        # Merges the per architecture libraries into a universal one.
         folder = os.path.join("build", "macos", config, "lib", "*.a")
         files = glob.glob(folder)
         files_str = " ".join(files)
@@ -173,7 +173,7 @@ def run_task_install():
         command = ["ls", "-lh ", lib_file_out]
         r.run(" ".join(command), shell=True)
 
-        # headers
+        # Copies the public headers.
         l.colored("Copying header files...", l.YELLOW)
 
         include_dir = os.path.join("build", "macos", "pdfium", "public")
@@ -196,7 +196,7 @@ def run_task_test():
     sample_dir = os.path.join(current_dir, "sample")
     build_dir = os.path.join(sample_dir, "build")
 
-    # configs
+    # Walks every configuration.
     for config in c.configurations_macos:
         f.recreate_dir(build_dir)
 
@@ -204,7 +204,7 @@ def run_task_test():
 
         cmake_config = config.capitalize()
 
-        # generate project
+        # Generates the sample project.
         command = [
             "cmake",
             "-DPDFIUM_CONFIG={0}".format(config),
@@ -213,21 +213,21 @@ def run_task_test():
         ]
         r.run(command)
 
-        # build
+        # Builds the sample.
         command = ["cmake", "--build", ".", "--config", cmake_config]
         r.run(command)
 
-        # copy assets
+        # Copies the assets the sample opens.
         f.copy_file(
             os.path.join(sample_dir, "assets", "f1.pdf"),
             os.path.join(build_dir, "f1.pdf"),
         )
 
-        # run
+        # Runs the sample.
         command = ["./sample"]
         r.run(command)
 
-        # finish
+        # Returns to the starting directory.
         os.chdir(current_dir)
 
     l.ok()

--- a/modules/macos.py
+++ b/modules/macos.py
@@ -196,30 +196,39 @@ def run_task_test():
     sample_dir = os.path.join(current_dir, "sample")
     build_dir = os.path.join(sample_dir, "build")
 
-    f.recreate_dir(build_dir)
+    # configs
+    for config in c.configurations_macos:
+        f.recreate_dir(build_dir)
 
-    os.chdir(build_dir)
+        os.chdir(build_dir)
 
-    # generate project
-    command = ["cmake", "../"]
-    r.run(command)
+        cmake_config = config.capitalize()
 
-    # build
-    command = ["cmake", "--build", "."]
-    r.run(command)
+        # generate project
+        command = [
+            "cmake",
+            "-DPDFIUM_CONFIG={0}".format(config),
+            "-DCMAKE_BUILD_TYPE={0}".format(cmake_config),
+            "../",
+        ]
+        r.run(command)
 
-    # copy assets
-    f.copy_file(
-        os.path.join(sample_dir, "assets", "f1.pdf"),
-        os.path.join(build_dir, "f1.pdf"),
-    )
+        # build
+        command = ["cmake", "--build", ".", "--config", cmake_config]
+        r.run(command)
 
-    # run
-    command = ["./sample"]
-    r.run(command)
+        # copy assets
+        f.copy_file(
+            os.path.join(sample_dir, "assets", "f1.pdf"),
+            os.path.join(build_dir, "f1.pdf"),
+        )
 
-    # finish
-    os.chdir(current_dir)
+        # run
+        command = ["./sample"]
+        r.run(command)
+
+        # finish
+        os.chdir(current_dir)
 
     l.ok()
 

--- a/modules/patch.py
+++ b/modules/patch.py
@@ -51,6 +51,7 @@ def apply_public_headers(target):
         l.bullet("Skipped: public headers (p2)", l.PURPLE)
 
 
+# -----------------------------------------------------------------------------
 # Returns the directory where the windows sdk is installed.
 def get_windows_sdk_dir():
     return os.environ.get(
@@ -59,6 +60,7 @@ def get_windows_sdk_dir():
     )
 
 
+# -----------------------------------------------------------------------------
 # Returns the newest usable windows sdk version installed, or None when there is none.
 def find_installed_windows_sdk_version(sdk_dir=None):
     if not sdk_dir:
@@ -120,6 +122,7 @@ def apply_windows_sdk_version(target):
         )
 
 
+# -----------------------------------------------------------------------------
 # Returns every windows api level the installed sdk defines, mapped to its numeric value.
 def find_installed_windows_ntddi_versions(sdk_dir=None):
     if not sdk_dir:

--- a/modules/patch.py
+++ b/modules/patch.py
@@ -52,12 +52,17 @@ def apply_public_headers(target):
 
 
 # -----------------------------------------------------------------------------
+def get_windows_sdk_dir():
+    return os.environ.get(
+        "WindowsSdkDir",
+        os.path.join("C:\\", "Program Files (x86)", "Windows Kits", "10"),
+    )
+
+
+# -----------------------------------------------------------------------------
 def find_installed_windows_sdk_version(sdk_dir=None):
     if not sdk_dir:
-        sdk_dir = os.environ.get(
-            "WindowsSdkDir",
-            os.path.join("C:\\", "Program Files (x86)", "Windows Kits", "10"),
-        )
+        sdk_dir = get_windows_sdk_dir()
 
     include_dir = os.path.join(sdk_dir, "Include")
 
@@ -113,3 +118,57 @@ def apply_windows_sdk_version(target):
         l.bullet(
             "Applied: windows sdk version {0} ({1})".format(version, name), l.GREEN
         )
+
+
+# -----------------------------------------------------------------------------
+def find_installed_windows_ntddi_versions(sdk_dir=None):
+    if not sdk_dir:
+        sdk_dir = get_windows_sdk_dir()
+
+    version = find_installed_windows_sdk_version(sdk_dir)
+
+    if not version:
+        return {}
+
+    header = os.path.join(sdk_dir, "Include", version, "shared", "sdkddkver.h")
+
+    if not os.path.isfile(header):
+        return {}
+
+    found = re.findall(
+        r"#define\s+(NTDDI_WIN\w+)\s+(0x[0-9A-Fa-f]+)", f.get_file_contents(header)
+    )
+
+    return {name: int(value, 16) for name, value in found}
+
+
+# -----------------------------------------------------------------------------
+def apply_windows_ntddi_version(target):
+    # chromium targets the ntddi level of the sdk it ships with. an older sdk
+    # does not define that name, so it expands to zero and every version guard
+    # in the windows headers hides the declarations the build needs
+    versions = find_installed_windows_ntddi_versions()
+
+    if not versions:
+        l.bullet("Skipped: windows ntddi version", l.PURPLE)
+        return
+
+    source_file = os.path.join(
+        "build", target, "pdfium", "build", "config", "win", "BUILD.gn"
+    )
+
+    found = re.search(r'"NTDDI_VERSION=(NTDDI_\w+)"', f.get_file_contents(source_file))
+
+    if not found:
+        l.bullet("Skipped: windows ntddi version", l.PURPLE)
+        return
+
+    if found.group(1) in versions:
+        l.bullet("Skipped: windows ntddi version", l.PURPLE)
+        return
+
+    newest = max(versions, key=versions.get)
+
+    f.replace_in_file(source_file, found.group(0), '"NTDDI_VERSION={0}"'.format(newest))
+
+    l.bullet("Applied: windows ntddi version {0}".format(newest), l.GREEN)

--- a/modules/patch.py
+++ b/modules/patch.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from pygemstones.io import file as f
 from pygemstones.util import log as l
@@ -48,3 +49,67 @@ def apply_public_headers(target):
         l.bullet("Applied: public headers (p2)", l.GREEN)
     else:
         l.bullet("Skipped: public headers (p2)", l.PURPLE)
+
+
+# -----------------------------------------------------------------------------
+def find_installed_windows_sdk_version(sdk_dir=None):
+    if not sdk_dir:
+        sdk_dir = os.environ.get(
+            "WindowsSdkDir",
+            os.path.join("C:\\", "Program Files (x86)", "Windows Kits", "10"),
+        )
+
+    include_dir = os.path.join(sdk_dir, "Include")
+
+    if not os.path.isdir(include_dir):
+        return None
+
+    versions = []
+
+    for name in os.listdir(include_dir):
+        parts = name.split(".")
+
+        # a version only counts when it carries the headers the build looks for
+        if not os.path.isdir(os.path.join(include_dir, name, "um")):
+            continue
+
+        if all(part.isdigit() for part in parts):
+            versions.append((tuple(int(part) for part in parts), name))
+
+    if not versions:
+        return None
+
+    return max(versions)[1]
+
+
+# -----------------------------------------------------------------------------
+def apply_windows_sdk_version(target):
+    # chromium pins the sdk version it ships with and hands it to vcvarsall, so
+    # a machine holding any other version fails before compiling anything
+    version = find_installed_windows_sdk_version()
+
+    if not version:
+        l.bullet("Skipped: windows sdk version", l.PURPLE)
+        return
+
+    build_dir = os.path.join("build", target, "pdfium", "build")
+
+    source_files = [
+        os.path.join(build_dir, "vs_toolchain.py"),
+        os.path.join(build_dir, "toolchain", "win", "setup_toolchain.py"),
+    ]
+
+    new_content = "SDK_VERSION = '{0}'".format(version)
+
+    for source_file in source_files:
+        name = os.path.basename(source_file)
+        found = re.search(r"SDK_VERSION = '[\d.]+'", f.get_file_contents(source_file))
+
+        if not found or found.group(0) == new_content:
+            l.bullet("Skipped: windows sdk version ({0})".format(name), l.PURPLE)
+            continue
+
+        f.replace_in_file(source_file, found.group(0), new_content)
+        l.bullet(
+            "Applied: windows sdk version {0} ({1})".format(version, name), l.GREEN
+        )

--- a/modules/patch.py
+++ b/modules/patch.py
@@ -51,7 +51,7 @@ def apply_public_headers(target):
         l.bullet("Skipped: public headers (p2)", l.PURPLE)
 
 
-# -----------------------------------------------------------------------------
+# Returns the directory where the windows sdk is installed.
 def get_windows_sdk_dir():
     return os.environ.get(
         "WindowsSdkDir",
@@ -59,7 +59,7 @@ def get_windows_sdk_dir():
     )
 
 
-# -----------------------------------------------------------------------------
+# Returns the newest usable windows sdk version installed, or None when there is none.
 def find_installed_windows_sdk_version(sdk_dir=None):
     if not sdk_dir:
         sdk_dir = get_windows_sdk_dir()
@@ -74,7 +74,7 @@ def find_installed_windows_sdk_version(sdk_dir=None):
     for name in os.listdir(include_dir):
         parts = name.split(".")
 
-        # a version only counts when it carries the headers the build looks for
+        # A version only counts when it carries the headers the build looks for.
         if not os.path.isdir(os.path.join(include_dir, name, "um")):
             continue
 
@@ -88,9 +88,9 @@ def find_installed_windows_sdk_version(sdk_dir=None):
 
 
 # -----------------------------------------------------------------------------
+# Points the pinned windows sdk version at one that is installed.
 def apply_windows_sdk_version(target):
-    # chromium pins the sdk version it ships with and hands it to vcvarsall, so
-    # a machine holding any other version fails before compiling anything
+    # Chromium pins the sdk version it ships with and hands it to vcvarsall, so any other version fails before compiling.
     version = find_installed_windows_sdk_version()
 
     if not version:
@@ -120,7 +120,7 @@ def apply_windows_sdk_version(target):
         )
 
 
-# -----------------------------------------------------------------------------
+# Returns every windows api level the installed sdk defines, mapped to its numeric value.
 def find_installed_windows_ntddi_versions(sdk_dir=None):
     if not sdk_dir:
         sdk_dir = get_windows_sdk_dir()
@@ -143,10 +143,9 @@ def find_installed_windows_ntddi_versions(sdk_dir=None):
 
 
 # -----------------------------------------------------------------------------
+# Points the pinned windows api level at one the installed sdk defines.
 def apply_windows_ntddi_version(target):
-    # chromium targets the ntddi level of the sdk it ships with. an older sdk
-    # does not define that name, so it expands to zero and every version guard
-    # in the windows headers hides the declarations the build needs
+    # An sdk that does not define the pinned level expands it to zero, and the version guards then hide the declarations the build needs.
     versions = find_installed_windows_ntddi_versions()
 
     if not versions:

--- a/modules/patch.py
+++ b/modules/patch.py
@@ -26,7 +26,7 @@ def apply_public_headers(target):
     source_dir = os.path.join("build", target, "pdfium")
     public_dir = os.path.join(source_dir, "public")
 
-    # file: public/fpdfview.h (p1)
+    # Removes the first component build guard from public/fpdfview.h.
     source_file = os.path.join(public_dir, "fpdfview.h")
 
     original_content = "#if defined(COMPONENT_BUILD)\n// FPDF_EXPORT should be consistent with |export| in the pdfium_fuzzer\n// template in testing/fuzzers/BUILD.gn."
@@ -38,7 +38,7 @@ def apply_public_headers(target):
     else:
         l.bullet("Skipped: public headers (p1)", l.PURPLE)
 
-    # file: public/fpdfview.h (p2)
+    # Removes the second component build guard from public/fpdfview.h.
     source_file = os.path.join(public_dir, "fpdfview.h")
 
     original_content = "#else\n#define FPDF_EXPORT\n#endif  // defined(COMPONENT_BUILD)"

--- a/modules/pdfium.py
+++ b/modules/pdfium.py
@@ -25,12 +25,12 @@ def get_pdfium_by_target(target, append_target_os=True, enable_v8=False):
     build_dir = os.path.join("build", target)
     f.create_dir(build_dir)
 
-    # remove old data
+    # Removes the previous checkout.
     l.colored("Removing old PDFium directory...", l.YELLOW)
     target_dir = os.path.join(build_dir, "pdfium")
     f.remove_dir(target_dir)
 
-    # clone pdfium
+    # Clones pdfium with gclient.
     l.colored("Cloning PDFium with gclient...", l.YELLOW)
     config_args = [
         "gclient",
@@ -44,7 +44,7 @@ def get_pdfium_by_target(target, append_target_os=True, enable_v8=False):
 
     run_gclient(config_args, build_dir)
 
-    # append target os
+    # Appends the target os to the gclient file.
     if append_target_os:
         l.colored(
             "Appending target os ({}) to gclient file...".format(target),
@@ -66,7 +66,7 @@ def get_pdfium_by_target(target, append_target_os=True, enable_v8=False):
         build_dir,
     )
 
-    # reset and clean directories
+    # Reverts the directories a previous patch task may have changed.
     folders_to_reset = [
         "pdfium",
         "pdfium/build",

--- a/modules/pdfium.py
+++ b/modules/pdfium.py
@@ -9,8 +9,9 @@ import modules.config as c
 
 
 # -----------------------------------------------------------------------------
+# Runs a gclient command, on any platform.
 def run_gclient(args, cwd):
-    # gclient is a batch file on windows and cannot be started without a shell
+    # On windows gclient is a batch file, which cannot be started without a shell.
     if sys.platform == "win32":
         r.run(" ".join(args), cwd=cwd, shell=True)
     else:

--- a/modules/pdfium.py
+++ b/modules/pdfium.py
@@ -1,10 +1,20 @@
 import os
+import sys
 
 from pygemstones.io import file as f
 from pygemstones.system import runner as r
 from pygemstones.util import log as l
 
 import modules.config as c
+
+
+# -----------------------------------------------------------------------------
+def run_gclient(args, cwd):
+    # gclient is a batch file on windows and cannot be started without a shell
+    if sys.platform == "win32":
+        r.run(" ".join(args), cwd=cwd, shell=True)
+    else:
+        r.run(args, cwd=cwd)
 
 
 # -----------------------------------------------------------------------------
@@ -31,7 +41,7 @@ def get_pdfium_by_target(target, append_target_os=True, enable_v8=False):
     if not enable_v8:
         config_args.extend(["--custom-var", "checkout_configuration=minimal"])
 
-    r.run(config_args, cwd=build_dir)
+    run_gclient(config_args, build_dir)
 
     # append target os
     if append_target_os:
@@ -43,7 +53,7 @@ def get_pdfium_by_target(target, append_target_os=True, enable_v8=False):
         f.append_to_file(gclient_file, "target_os = [ '{}' ]".format(target))
 
     l.colored(f"Syncing repository with branch {c.pdfium_git_branch}...", l.YELLOW)
-    r.run(
+    run_gclient(
         [
             "gclient",
             "sync",
@@ -52,7 +62,7 @@ def get_pdfium_by_target(target, append_target_os=True, enable_v8=False):
             "--no-history",
             "--shallow",
         ],
-        cwd=build_dir,
+        build_dir,
     )
 
     # reset and clean directories

--- a/modules/wasm.py
+++ b/modules/wasm.py
@@ -46,7 +46,8 @@ def run_task_patch():
 
     if not line_number:
         source = """} else if (target_os == "emscripten") {
-  # Removing every target in //BUILD.gn that does not work with it is too hard.
+  # Because it's too hard to remove all targets from //BUILD.gn that do not work
+  # with it.
   assert(
       false,
       "emscripten is not a supported target_os. It is available only as secondary toolchain.")

--- a/modules/wasm.py
+++ b/modules/wasm.py
@@ -23,15 +23,15 @@ def run_task_patch():
 
     source_dir = os.path.join("build", "emscripten", "pdfium")
 
-    # shared lib
+    # Turns the library target into a shared one.
     if c.shared_lib_wasm:
         patch.apply_shared_library("emscripten")
 
-    # public headers
+    # Removes the component build guards from the public headers.
     if c.shared_lib_wasm:
         patch.apply_public_headers("emscripten")
 
-    # build target
+    # Adjusts the build target for emscripten.
     source_file = os.path.join(
         source_dir,
         "build",
@@ -46,8 +46,7 @@ def run_task_patch():
 
     if not line_number:
         source = """} else if (target_os == "emscripten") {
-  # Because it's too hard to remove all targets from //BUILD.gn that do not work
-  # with it.
+  # Removing every target in //BUILD.gn that does not work with it is too hard.
   assert(
       false,
       "emscripten is not a supported target_os. It is available only as secondary toolchain.")
@@ -62,7 +61,7 @@ def run_task_patch():
     else:
         l.bullet("Skipped: build target", l.PURPLE)
 
-    # compiler
+    # Adjusts the compiler configuration.
     source_file = os.path.join(
         source_dir,
         "build",
@@ -92,7 +91,7 @@ def run_task_patch():
     else:
         l.bullet("Skipped: build compiler", l.PURPLE)
 
-    # stack protector
+    # Disables the stack protector.
     source_file = os.path.join(
         source_dir,
         "build",
@@ -116,7 +115,7 @@ def run_task_patch():
     else:
         l.bullet("Skipped: stack protector", l.PURPLE)
 
-    # fxcrt
+    # Adjusts the fxcrt target.
     source_file = os.path.join(
         source_dir,
         "core",
@@ -138,7 +137,7 @@ def run_task_patch():
     else:
         l.bullet("Skipped: fxcrt", l.PURPLE)
 
-    # fxge
+    # Adjusts the fxge target.
     source_file = os.path.join(
         source_dir,
         "core",
@@ -160,7 +159,7 @@ def run_task_patch():
     else:
         l.bullet("Skipped: fxge", l.PURPLE)
 
-    # build config
+    # Adjusts the build configuration.
     source_file = os.path.join(
         source_dir,
         "build",
@@ -172,8 +171,7 @@ def run_task_patch():
     if not f.file_exists(source_file):
         content = """config("compiler") {
   defines = [
-    # Enable fseeko() and ftello() (required by libopenjpeg20)
-    # https://github.com/emscripten-core/emscripten/issues/4932
+    # Enables fseeko() and ftello(), which libopenjpeg20 requires, as described in https://github.com/emscripten-core/emscripten/issues/4932.
     "_POSIX_C_SOURCE=200112",
   ]
 }"""
@@ -184,7 +182,7 @@ def run_task_patch():
     else:
         l.bullet("Skipped: build config", l.PURPLE)
 
-    # toolchain warn
+    # Silences the unknown warning options of the toolchain.
     source_file = os.path.join(
         source_dir,
         "build",
@@ -207,7 +205,7 @@ def run_task_patch():
     else:
         l.bullet("Skipped: toolchain warn", l.PURPLE)
 
-    # toolchain wasm
+    # Points the toolchain at the installed emscripten.
     source_file = os.path.join(
         source_dir,
         "build",
@@ -231,7 +229,7 @@ def run_task_patch():
     else:
         l.bullet("Skipped: toolchain wasm", l.PURPLE)
 
-    # skia
+    # Drops the skia dependency, which the wasm build does not use.
     source_file = os.path.join(
         source_dir,
         "BUILD.gn",
@@ -259,9 +257,9 @@ def run_task_build():
 
     current_dir = f.current_dir()
 
-    # configs
+    # Walks every configuration.
     for config in c.configurations_wasm:
-        # targets
+        # Walks every target.
         for target in c.targets_wasm:
             main_dir = os.path.join(
                 "build",
@@ -281,7 +279,7 @@ def run_task_build():
                 )
             )
 
-            # generating files...
+            # Generates the ninja files.
             l.colored(
                 'Generating files to arch "{0}" and configuration "{1}"...'.format(
                     target["target_cpu"], config
@@ -308,7 +306,7 @@ def run_task_build():
             ]
             r.run(" ".join(command), shell=True)
 
-            # compiling...
+            # Compiles the library.
             l.colored(
                 'Compiling to arch "{0}" and configuration "{1}"...'.format(
                     target["target_cpu"], config
@@ -336,7 +334,7 @@ def run_task_build():
 def run_task_install():
     l.colored("Installing libraries...", l.YELLOW)
 
-    # configs
+    # Walks every configuration.
     for config in c.configurations_wasm:
         for target in c.targets_wasm:
             f.recreate_dir(
@@ -370,7 +368,7 @@ def run_task_install():
 
             f.copy_file(source_lib_path, target_lib_path)
 
-            # fix include path
+            # Rewrites the public includes so they resolve outside the checkout.
             source_include_path = os.path.join(
                 "build",
                 target["target_os"],
@@ -383,7 +381,7 @@ def run_task_install():
             for header in headers:
                 f.replace_in_file(header, '#include "public/', '#include "../')
 
-            # check file
+            # Reports the resulting file.
             l.colored("File data...", l.YELLOW)
             command = ["file", target_lib_path]
             r.run(" ".join(command), shell=True)
@@ -392,7 +390,7 @@ def run_task_install():
             command = ["ls", "-lh ", target_lib_path]
             r.run(" ".join(command), shell=True)
 
-            # headers
+            # Copies the public headers.
             l.colored("Copying header files...", l.YELLOW)
 
             include_dir = os.path.join("build", "emscripten", "pdfium", "public")
@@ -448,7 +446,7 @@ def run_task_test():
 
             f.recreate_dir(build_dir)
 
-            # build
+            # Builds the sample.
             command = [
                 "em++",
                 "{0}".format("-g" if config == "debug" else ""),
@@ -501,7 +499,7 @@ def run_task_test_wasmtime():
                 l.YELLOW,
             )
 
-            # paths
+            # Resolves the directories used below.
             relative_dir = os.path.join(
                 "build",
                 target["target_os"],
@@ -513,18 +511,18 @@ def run_task_test_wasmtime():
             node_dir = os.path.join(root_dir, "node")
             wasm_file = os.path.join(node_dir, "pdfium.std.wasm")
 
-            # check if wasm file exists
+            # Requires the wasm file to exist.
             if not f.file_exists(wasm_file):
                 l.e(f"WASM file not found: {wasm_file}")
                 continue
 
             l.bullet(f"WASM file: {wasm_file}", l.YELLOW)
 
-            # create engine and load the pdfium.wasm module
+            # Creates the engine and loads the pdfium.wasm module.
             engine = Engine()
             module = Module.from_file(engine, wasm_file)
 
-            # create WASI context and store
+            # Creates the WASI context and the store.
             wasi_config = WasiConfig()
             wasi_config.inherit_stdin()
             wasi_config.inherit_stdout()
@@ -533,23 +531,23 @@ def run_task_test_wasmtime():
             store = Store(engine)
             store.set_wasi(wasi_config)
 
-            # create a linker and add WASI support
+            # Creates a linker with WASI support.
             linker = Linker(engine)
             linker.define_wasi()
 
-            # define stub functions for unknown imports
+            # Defines stub functions for the unknown imports.
             for imp in module.imports:
                 module_name = imp.module
                 field_name = imp.name
 
-                # check if this is a function import
+                # Only function imports need a stub.
                 if isinstance(imp.type, FuncType):
                     func_type = imp.type
 
-                    # create a stub function that returns default values
+                    # Creates a stub function returning default values.
                     def make_stub(ft):
                         def stub_func(*_args):
-                            # return default values (0 or None) based on results
+                            # Returns zero or None according to the declared results.
                             if ft.results:
                                 if len(ft.results) == 1:
                                     return 0
@@ -563,14 +561,14 @@ def run_task_test_wasmtime():
                             module_name, field_name, func_type, make_stub(func_type)
                         )
                     except Exception:
-                        # already defined (e.g., by WASI)
+                        # The import is already defined, by WASI for example.
                         pass
 
-            # instantiate the module
+            # Instantiates the module.
             instance = linker.instantiate(store, module)
             exports = instance.exports(store)
 
-            # get and call FPDF_InitLibrary function
+            # Calls FPDF_InitLibrary.
             try:
                 init_library = exports["FPDF_InitLibrary"]
                 init_library(store)
@@ -579,7 +577,7 @@ def run_task_test_wasmtime():
                 l.e("Function 'FPDF_InitLibrary' not found")
                 continue
 
-            # test with a sample PDF file
+            # Tests with a sample PDF file.
             sample_pdf = os.path.join(
                 current_dir, "sample-wasm", "assets", "web-assembly.pdf"
             )
@@ -590,23 +588,23 @@ def run_task_test_wasmtime():
 
             l.bullet(f"Testing with PDF: {sample_pdf}", l.YELLOW)
 
-            # read PDF data
+            # Reads the PDF data.
             pdf_path = Path(sample_pdf)
             pdf_data = pdf_path.read_bytes()
 
-            # allocate memory for the PDF data
+            # Allocates memory for the PDF data.
             malloc = exports["malloc"]
             memory = exports["memory"]
 
-            # allocate buffer in WASM memory
+            # Allocates the buffer in the WASM memory.
             buf_ptr = malloc(store, len(pdf_data))
             mem_data = memory.data_ptr(store)
 
-            # copy PDF data to WASM memory
+            # Copies the PDF data into the WASM memory.
             for i, byte in enumerate(pdf_data):
                 mem_data[buf_ptr + i] = byte
 
-            # load the PDF document from memory
+            # Loads the PDF document from memory.
             fpdf_load_mem_document = exports["FPDF_LoadMemDocument"]
             doc = fpdf_load_mem_document(store, buf_ptr, len(pdf_data), 0)
 
@@ -615,23 +613,23 @@ def run_task_test_wasmtime():
                 error = get_last_error(store)
                 l.e(f"Failed to load PDF. Error code: {error}")
 
-                # free the allocated memory
+                # Frees the allocated memory.
                 free = exports["free"]
                 free(store, buf_ptr)
                 continue
 
-            # get page count
+            # Reads the page count.
             fpdf_get_page_count = exports["FPDF_GetPageCount"]
             page_count = fpdf_get_page_count(store, doc)
 
             l.bullet(f"PDF: {pdf_path.name}", l.GREEN)
             l.bullet(f"Number of pages: {page_count}", l.GREEN)
 
-            # close the document
+            # Closes the document.
             fpdf_close_document = exports["FPDF_CloseDocument"]
             fpdf_close_document(store, doc)
 
-            # free the allocated memory
+            # Frees the allocated memory.
             free = exports["free"]
             free(store, buf_ptr)
 
@@ -648,7 +646,7 @@ def run_task_generate():
 
     for config in c.configurations_wasm:
         for target in c.targets_wasm:
-            # paths
+            # Resolves the directories used below.
             utils_dir = os.path.join(current_dir, "extras", "wasm", "utils")
             template_dir = os.path.join(current_dir, "extras", "wasm", "template")
 
@@ -669,7 +667,7 @@ def run_task_generate():
 
             f.recreate_dir(gen_dir)
 
-            # doxygen
+            # Runs doxygen.
             l.colored("Doxygen...", l.YELLOW)
 
             doxygen_file = os.path.join(
@@ -686,18 +684,18 @@ def run_task_generate():
             ]
             r.run(" ".join(command), cwd=include_dir, shell=True)
 
-            # copy xml files
+            # Copies the xml files.
             l.colored("Copying xml files...", l.YELLOW)
 
             xml_dir = os.path.join(include_dir, "xml")
             f.copy_dir(xml_dir, os.path.join(gen_dir, "xml"))
             f.remove_dir(xml_dir)
 
-            # copy utils files
+            # Copies the utils files.
             l.colored("Copying utils files...", l.YELLOW)
             f.copy_dir(utils_dir, os.path.join(gen_dir, "utils"))
 
-            # node modules
+            # Installs the node modules.
             l.colored("Installing node modules...", l.YELLOW)
 
             gen_utils_dir = os.path.join(
@@ -711,7 +709,7 @@ def run_task_generate():
             ]
             r.run(" ".join(command), cwd=gen_utils_dir, shell=True)
 
-            # generate
+            # Generates the module.
             l.colored("Compiling with emscripten...", l.YELLOW)
 
             gen_out_dir = os.path.join(
@@ -774,7 +772,7 @@ def run_task_generate():
                 "--no-entry",
             ]
 
-            # Generate UMD (CommonJS + AMD) module and .wasm file
+            # Generates the UMD module, for CommonJS and AMD, along with the wasm file.
             umd_command = [
                 *base_command,
                 "-o",
@@ -782,7 +780,7 @@ def run_task_generate():
             ]
             r.run(" ".join(umd_command), cwd=gen_utils_dir, shell=True)
 
-            # Generate ES6 module, only .js will be generated (no .wasm)
+            # Generates the ES6 module, which produces only the js file.
             l.colored("Compiling ES6 module with emscripten...", l.YELLOW)
             es6_command = [
                 *base_command,
@@ -793,7 +791,7 @@ def run_task_generate():
             ]
             r.run(" ".join(es6_command), cwd=gen_utils_dir, shell=True)
 
-            # Generate STANDALONE module, only .js will be generated (no .wasm)
+            # Generates the standalone module, which produces only the js file.
             l.colored("Compiling STANDALONE module with emscripten...", l.YELLOW)
             std_command = [
                 *base_command,
@@ -807,13 +805,13 @@ def run_task_generate():
             ]
             r.run(" ".join(std_command), cwd=gen_utils_dir, shell=True)
 
-            # copy files
+            # Copies the compiled files.
             l.colored("Copying compiled files...", l.YELLOW)
 
             f.remove_dir(node_dir)
             f.copy_dir(gen_out_dir, node_dir)
 
-            # copy template files
+            # Copies the template files.
             l.colored("Copying template files...", l.YELLOW)
 
             f.copy_file(
@@ -836,7 +834,7 @@ def run_task_generate():
                 os.path.join(main_dir, "package.json"),
             )
 
-            # change template tags
+            # Replaces the template tags.
             l.colored("Replacing template tags...", l.YELLOW)
 
             f.replace_in_file(
@@ -851,7 +849,7 @@ def run_task_generate():
                 c.pdfium_git_branch.strip("chromium/"),
             )
 
-            # test
+            # Reports how to test it on a browser.
             l.colored(
                 "Test on browser with: python3 -m http.server --directory {0}".format(
                     http_dir
@@ -873,17 +871,17 @@ def run_task_publish():
     )
     template_dir = os.path.join(current_dir, "extras", "wasm", "template")
 
-    # copy generated files
+    # Copies the generated files.
     f.remove_dir(publish_dir)
     f.copy_dir(node_dir, publish_dir)
 
-    # copy template files
+    # Copies the template files.
     f.copy_file(
         os.path.join(template_dir, "README.md"),
         os.path.join(publish_dir, "README.md"),
     )
 
-    # finish
+    # Returns to the starting directory.
     l.ok()
 
 
@@ -898,17 +896,17 @@ def run_task_publish_to_web():
     )
     template_dir = os.path.join(current_dir, "extras", "wasm", "template")
 
-    # copy generated files
+    # Copies the generated files.
     f.remove_dir(publish_dir)
     f.copy_dir(node_dir, publish_dir)
 
-    # copy template files
+    # Copies the template files.
     f.copy_file(
         os.path.join(template_dir, "README.md"),
         os.path.join(publish_dir, "README.md"),
     )
 
-    # clone gh-pages branch
+    # Clones the gh-pages branch.
     command = "git init ."
     r.run(command, cwd=publish_dir, shell=True)
 
@@ -924,7 +922,7 @@ def run_task_publish_to_web():
     command = 'git push "git@github.com:pdfviewer/pdfviewer.github.io.git" master:master --force'
     r.run(command, cwd=publish_dir, shell=True)
 
-    # finish
+    # Returns to the starting directory.
     l.colored("Test on browser: https://pdfviewer.github.io/", l.YELLOW)
 
     l.ok()
@@ -955,13 +953,13 @@ def run_task_archive():
                 filter=filter_files,
             )
 
-            # Create per config "npm install"-compatible tarball
+            # Creates a tarball per configuration that npm install accepts.
             per_config_tar = tarfile.open(
                 os.path.join(current_dir, f"wasm-{config}.tgz"), "w:gz"
             )
             per_config_tar.add(
                 name=lib_dir,
-                # Use "package" as the root directory to be compatible with "npm install"
+                # The root directory has to be named package for npm install to accept it.
                 arcname="package",
                 filter=filter_files,
             )

--- a/modules/windows.py
+++ b/modules/windows.py
@@ -1,0 +1,246 @@
+import os
+import tarfile
+
+from pygemstones.io import file as f
+from pygemstones.system import runner as r
+from pygemstones.util import log as l
+
+import modules.common as cm
+import modules.config as c
+import modules.patch as patch
+import modules.pdfium as p
+
+
+# -----------------------------------------------------------------------------
+def run_task_build_pdfium():
+    p.get_pdfium_by_target("windows")
+
+
+# -----------------------------------------------------------------------------
+def run_task_patch():
+    l.colored("Patching files...", l.YELLOW)
+
+    # shared lib
+    if c.shared_lib_windows:
+        patch.apply_shared_library("windows")
+
+    # public headers
+    if c.shared_lib_windows:
+        patch.apply_public_headers("windows")
+
+    l.ok()
+
+
+# -----------------------------------------------------------------------------
+def run_task_build():
+    l.colored("Building libraries...", l.YELLOW)
+
+    current_dir = f.current_dir()
+
+    # configs
+    for config in c.configurations_windows:
+        # targets
+        for target in c.targets_windows:
+            main_dir = os.path.join(
+                "build",
+                target["target_os"],
+                "pdfium",
+                "out",
+                "{0}-{1}-{2}".format(target["target_os"], target["target_cpu"], config),
+            )
+
+            f.recreate_dir(main_dir)
+
+            os.chdir(
+                os.path.join(
+                    "build",
+                    target["target_os"],
+                    "pdfium",
+                )
+            )
+
+            # generating files...
+            l.colored(
+                'Generating files to arch "{0}" and configuration "{1}"...'.format(
+                    target["target_cpu"], config
+                ),
+                l.YELLOW,
+            )
+
+            args = cm.get_build_args(
+                config,
+                c.shared_lib_windows,
+                target["pdfium_os"],
+                target["target_cpu"],
+            )
+
+            # the windows shell does not keep the single quotes the other targets rely on
+            args_str = " ".join(args).replace('"', '\\"')
+
+            command = [
+                "gn",
+                "gen",
+                "out/{0}-{1}-{2}".format(
+                    target["target_os"], target["target_cpu"], config
+                ),
+                '--args="{0}"'.format(args_str),
+            ]
+            r.run(" ".join(command), shell=True)
+
+            # compiling...
+            l.colored(
+                'Compiling to arch "{0}" and configuration "{1}"...'.format(
+                    target["target_cpu"], config
+                ),
+                l.YELLOW,
+            )
+
+            command = [
+                "ninja",
+                "-C",
+                "out/{0}-{1}-{2}".format(
+                    target["target_os"], target["target_cpu"], config
+                ),
+                "pdfium",
+                "-v",
+            ]
+            r.run(" ".join(command), shell=True)
+
+            os.chdir(current_dir)
+
+    l.ok()
+
+
+# -----------------------------------------------------------------------------
+def run_task_install():
+    l.colored("Installing libraries...", l.YELLOW)
+
+    # configs
+    for config in c.configurations_windows:
+        f.recreate_dir(os.path.join("build", "windows", config))
+        f.create_dir(os.path.join("build", "windows", config, "lib"))
+
+        # targets
+        for target in c.targets_windows:
+            out_dir = os.path.join(
+                "build",
+                target["target_os"],
+                "pdfium",
+                "out",
+                "{0}-{1}-{2}".format(target["target_os"], target["target_cpu"], config),
+            )
+
+            # there is no fat binary on windows, so each arch keeps its own directory
+            target_lib_dir = os.path.join(
+                "build",
+                target["target_os"],
+                config,
+                "lib",
+                target["target_cpu"],
+            )
+
+            # a shared build produces the dll plus its import library, a static one
+            # produces a single lib under obj
+            if c.shared_lib_windows:
+                artifacts = [
+                    (os.path.join(out_dir, "pdfium.dll"), "pdfium.dll"),
+                    (os.path.join(out_dir, "pdfium.dll.lib"), "pdfium.dll.lib"),
+                ]
+            else:
+                artifacts = [
+                    (os.path.join(out_dir, "obj", "pdfium.lib"), "pdfium.lib"),
+                ]
+
+            for source_lib_path, lib_file_name in artifacts:
+                f.copy_file(
+                    source_lib_path, os.path.join(target_lib_dir, lib_file_name)
+                )
+
+            # fix include path
+            source_include_path = os.path.join(
+                "build",
+                target["target_os"],
+                "pdfium",
+                "public",
+            )
+
+            headers = f.find_files(source_include_path, "*.h", True)
+
+            for header in headers:
+                f.replace_in_file(header, '#include "public/', '#include "../')
+
+        # headers
+        l.colored("Copying header files...", l.YELLOW)
+
+        include_dir = os.path.join("build", "windows", "pdfium", "public")
+        include_cpp_dir = os.path.join(include_dir, "cpp")
+        target_include_dir = os.path.join("build", "windows", config, "include")
+        target_include_cpp_dir = os.path.join(target_include_dir, "cpp")
+
+        f.recreate_dir(target_include_dir)
+        f.copy_files(include_dir, target_include_dir, "*.h")
+        f.copy_files(include_cpp_dir, target_include_cpp_dir, "*.h")
+
+    l.ok()
+
+
+# -----------------------------------------------------------------------------
+def run_task_test():
+    l.colored("Testing...", l.YELLOW)
+
+    current_dir = os.getcwd()
+    sample_dir = os.path.join(current_dir, "sample")
+    build_dir = os.path.join(sample_dir, "build")
+
+    f.recreate_dir(build_dir)
+
+    os.chdir(build_dir)
+
+    # generate project
+    command = ["cmake", "../"]
+    r.run(command)
+
+    # build
+    command = ["cmake", "--build", ".", "--config", "Release"]
+    r.run(command)
+
+    # copy assets
+    f.copy_file(
+        os.path.join(sample_dir, "assets", "f1.pdf"),
+        os.path.join(build_dir, "f1.pdf"),
+    )
+
+    # run
+    # visual studio is a multi config generator, so the binary lands in a subfolder
+    sample_path = os.path.join("Release", "sample.exe")
+
+    if not f.file_exists(sample_path):
+        sample_path = "sample.exe"
+
+    r.run([sample_path])
+
+    # finish
+    os.chdir(current_dir)
+
+    l.ok()
+
+
+# -----------------------------------------------------------------------------
+def run_task_archive():
+    l.colored("Archiving...", l.YELLOW)
+
+    current_dir = f.current_dir()
+    lib_dir = os.path.join(current_dir, "build", "windows")
+    output_filename = os.path.join(current_dir, "windows.tgz")
+
+    tar = tarfile.open(output_filename, "w:gz")
+
+    for configuration in c.configurations_windows:
+        tar.add(
+            name=os.path.join(lib_dir, configuration),
+            arcname=os.path.basename(os.path.join(lib_dir, configuration)),
+        )
+
+    tar.close()
+
+    l.ok()

--- a/modules/windows.py
+++ b/modules/windows.py
@@ -28,6 +28,9 @@ def run_task_patch():
     if c.shared_lib_windows:
         patch.apply_public_headers("windows")
 
+    # windows sdk
+    patch.apply_windows_sdk_version("windows")
+
     l.ok()
 
 

--- a/modules/windows.py
+++ b/modules/windows.py
@@ -78,7 +78,7 @@ def run_task_build():
                 target["target_cpu"],
             )
 
-            # the windows shell does not keep the single quotes the other targets rely on
+            # The windows shell does not keep the single quotes the other targets rely on.
             args_str = " ".join(args).replace('"', '\\"')
 
             command = [

--- a/modules/windows.py
+++ b/modules/windows.py
@@ -30,6 +30,7 @@ def run_task_patch():
 
     # windows sdk
     patch.apply_windows_sdk_version("windows")
+    patch.apply_windows_ntddi_version("windows")
 
     l.ok()
 

--- a/modules/windows.py
+++ b/modules/windows.py
@@ -136,7 +136,6 @@ def run_task_install():
                 "pdfium.lib",
             )
 
-            # there is no fat binary on windows, so each arch keeps its own directory
             target_lib_path = os.path.join(
                 "build",
                 target["target_os"],
@@ -184,30 +183,39 @@ def run_task_test():
     sample_dir = os.path.join(current_dir, "sample")
     build_dir = os.path.join(sample_dir, "build")
 
-    f.recreate_dir(build_dir)
+    # configs
+    for config in c.configurations_windows:
+        f.recreate_dir(build_dir)
 
-    os.chdir(build_dir)
+        os.chdir(build_dir)
 
-    # generate project
-    command = ["cmake", "../"]
-    r.run(command)
+        cmake_config = config.capitalize()
 
-    # build
-    command = ["cmake", "--build", ".", "--config", "Release"]
-    r.run(command)
+        # generate project
+        command = [
+            "cmake",
+            "-DPDFIUM_CONFIG={0}".format(config),
+            "-DCMAKE_BUILD_TYPE={0}".format(cmake_config),
+            "../",
+        ]
+        r.run(command)
 
-    # copy assets
-    f.copy_file(
-        os.path.join(sample_dir, "assets", "f1.pdf"),
-        os.path.join(build_dir, "f1.pdf"),
-    )
+        # build
+        command = ["cmake", "--build", ".", "--config", cmake_config]
+        r.run(command)
 
-    # run
-    command = ["sample.exe"]
-    r.run(command)
+        # copy assets
+        f.copy_file(
+            os.path.join(sample_dir, "assets", "f1.pdf"),
+            os.path.join(build_dir, "f1.pdf"),
+        )
 
-    # finish
-    os.chdir(current_dir)
+        # run
+        command = ["sample.exe"]
+        r.run(command)
+
+        # finish
+        os.chdir(current_dir)
 
     l.ok()
 

--- a/modules/windows.py
+++ b/modules/windows.py
@@ -20,15 +20,15 @@ def run_task_build_pdfium():
 def run_task_patch():
     l.colored("Patching files...", l.YELLOW)
 
-    # shared lib
+    # Turns the library target into a shared one.
     if c.shared_lib_windows:
         patch.apply_shared_library("windows")
 
-    # public headers
+    # Removes the component build guards from the public headers.
     if c.shared_lib_windows:
         patch.apply_public_headers("windows")
 
-    # windows sdk
+    # Aligns the pinned toolchain versions with the installed sdk.
     patch.apply_windows_sdk_version("windows")
     patch.apply_windows_ntddi_version("windows")
 
@@ -41,9 +41,9 @@ def run_task_build():
 
     current_dir = f.current_dir()
 
-    # configs
+    # Walks every configuration.
     for config in c.configurations_windows:
-        # targets
+        # Walks every target.
         for target in c.targets_windows:
             main_dir = os.path.join(
                 "build",
@@ -63,7 +63,7 @@ def run_task_build():
                 )
             )
 
-            # generating files...
+            # Generates the ninja files.
             l.colored(
                 'Generating files to arch "{0}" and configuration "{1}"...'.format(
                     target["target_cpu"], config
@@ -91,7 +91,7 @@ def run_task_build():
             ]
             r.run(" ".join(command), shell=True)
 
-            # compiling...
+            # Compiles the library.
             l.colored(
                 'Compiling to arch "{0}" and configuration "{1}"...'.format(
                     target["target_cpu"], config
@@ -119,12 +119,12 @@ def run_task_build():
 def run_task_install():
     l.colored("Installing libraries...", l.YELLOW)
 
-    # configs
+    # Walks every configuration.
     for config in c.configurations_windows:
         f.recreate_dir(os.path.join("build", "windows", config))
         f.create_dir(os.path.join("build", "windows", config, "lib"))
 
-        # targets
+        # Walks every target.
         for target in c.targets_windows:
             source_lib_path = os.path.join(
                 "build",
@@ -147,7 +147,7 @@ def run_task_install():
 
             f.copy_file(source_lib_path, target_lib_path)
 
-            # fix include path
+            # Rewrites the public includes so they resolve outside the checkout.
             source_include_path = os.path.join(
                 "build",
                 target["target_os"],
@@ -160,7 +160,7 @@ def run_task_install():
             for header in headers:
                 f.replace_in_file(header, '#include "public/', '#include "../')
 
-        # headers
+        # Copies the public headers.
         l.colored("Copying header files...", l.YELLOW)
 
         include_dir = os.path.join("build", "windows", "pdfium", "public")
@@ -183,7 +183,7 @@ def run_task_test():
     sample_dir = os.path.join(current_dir, "sample")
     build_dir = os.path.join(sample_dir, "build")
 
-    # configs
+    # Walks every configuration.
     for config in c.configurations_windows:
         f.recreate_dir(build_dir)
 
@@ -191,7 +191,7 @@ def run_task_test():
 
         cmake_config = config.capitalize()
 
-        # generate project
+        # Generates the sample project.
         command = [
             "cmake",
             "-DPDFIUM_CONFIG={0}".format(config),
@@ -200,21 +200,21 @@ def run_task_test():
         ]
         r.run(command)
 
-        # build
+        # Builds the sample.
         command = ["cmake", "--build", ".", "--config", cmake_config]
         r.run(command)
 
-        # copy assets
+        # Copies the assets the sample opens.
         f.copy_file(
             os.path.join(sample_dir, "assets", "f1.pdf"),
             os.path.join(build_dir, "f1.pdf"),
         )
 
-        # run
+        # Runs the sample.
         command = ["sample.exe"]
         r.run(command)
 
-        # finish
+        # Returns to the starting directory.
         os.chdir(current_dir)
 
     l.ok()

--- a/modules/windows.py
+++ b/modules/windows.py
@@ -126,39 +126,27 @@ def run_task_install():
 
         # targets
         for target in c.targets_windows:
-            out_dir = os.path.join(
+            source_lib_path = os.path.join(
                 "build",
                 target["target_os"],
                 "pdfium",
                 "out",
                 "{0}-{1}-{2}".format(target["target_os"], target["target_cpu"], config),
+                "obj",
+                "pdfium.lib",
             )
 
             # there is no fat binary on windows, so each arch keeps its own directory
-            target_lib_dir = os.path.join(
+            target_lib_path = os.path.join(
                 "build",
                 target["target_os"],
                 config,
                 "lib",
                 target["target_cpu"],
+                "pdfium.lib",
             )
 
-            # a shared build produces the dll plus its import library, a static one
-            # produces a single lib under obj
-            if c.shared_lib_windows:
-                artifacts = [
-                    (os.path.join(out_dir, "pdfium.dll"), "pdfium.dll"),
-                    (os.path.join(out_dir, "pdfium.dll.lib"), "pdfium.dll.lib"),
-                ]
-            else:
-                artifacts = [
-                    (os.path.join(out_dir, "obj", "pdfium.lib"), "pdfium.lib"),
-                ]
-
-            for source_lib_path, lib_file_name in artifacts:
-                f.copy_file(
-                    source_lib_path, os.path.join(target_lib_dir, lib_file_name)
-                )
+            f.copy_file(source_lib_path, target_lib_path)
 
             # fix include path
             source_include_path = os.path.join(
@@ -215,13 +203,8 @@ def run_task_test():
     )
 
     # run
-    # visual studio is a multi config generator, so the binary lands in a subfolder
-    sample_path = os.path.join("Release", "sample.exe")
-
-    if not f.file_exists(sample_path):
-        sample_path = "sample.exe"
-
-    r.run([sample_path])
+    command = ["sample.exe"]
+    r.run(command)
 
     # finish
     os.chdir(current_dir)

--- a/sample-wasm/src/main.cpp
+++ b/sample-wasm/src/main.cpp
@@ -4,8 +4,6 @@
 
 int main(int argc, char **argv)
 {
-    // Adapted from https://github.com/lukas-w/pdfium/blob/master/docs/getting-started.md.
-
     std::cout << "Starting..." << std::endl;
 
     FPDF_LIBRARY_CONFIG config;

--- a/sample-wasm/src/main.cpp
+++ b/sample-wasm/src/main.cpp
@@ -4,7 +4,7 @@
 
 int main(int argc, char **argv)
 {
-    // sample: https://github.com/lukas-w/pdfium/blob/master/docs/getting-started.md
+    // Adapted from https://github.com/lukas-w/pdfium/blob/master/docs/getting-started.md.
 
     std::cout << "Starting..." << std::endl;
 

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -15,7 +15,7 @@ endforeach()
 # The pdfium build to link against, which decides the library directory and the runtime.
 set(PDFIUM_CONFIG "release" CACHE STRING "pdfium build configuration")
 
-# platform
+# Resolves the platform directory name.
 if(APPLE)
     set(PDFIUM_PLATFORM "macos")
 elseif(WIN32)
@@ -27,7 +27,7 @@ endif()
 set(PDFIUM_DIR "../build/${PDFIUM_PLATFORM}/${PDFIUM_CONFIG}")
 set(PDFIUM_INCLUDE_DIR "${PDFIUM_DIR}/include")
 
-# macOS ships a single universal library, while the other platforms keep one directory per architecture.
+# A single universal library is shipped on macOS, while the other platforms keep one directory per architecture.
 if(APPLE)
     set(PDFIUM_LIB_DIR "${PDFIUM_DIR}/lib")
 else()
@@ -40,7 +40,7 @@ else()
     set(PDFIUM_LIB_DIR "${PDFIUM_DIR}/lib/${PDFIUM_ARCH}")
 endif()
 
-# sources
+# Collects the sources.
 file(GLOB S_FILES_PROJECT "src/*.cpp")
 file(GLOB H_FILES_PDFIUM "${PDFIUM_INCLUDE_DIR}/*.h")
 
@@ -50,10 +50,10 @@ set(
     ${H_FILES_PDFIUM}
 )
 
-# target
+# Declares the executable.
 add_executable(${PROJECT_NAME} ${PROJ_FILES})
 
-# links
+# Links what each platform needs.
 target_link_libraries(${PROJECT_NAME} PRIVATE "pdfium")
 
 if(APPLE)
@@ -81,6 +81,6 @@ else()
     target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
 endif()
 
-# paths
+# Points the compiler and the linker at the staged library.
 target_link_directories(${PROJECT_NAME} PRIVATE ${PDFIUM_LIB_DIR})
 target_include_directories(${PROJECT_NAME} PRIVATE ${PDFIUM_INCLUDE_DIR})

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -4,14 +4,16 @@ project(sample)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# multi config generators put the binary under a per configuration directory,
-# so pin the output and every platform finds it in the same place
+# multi config generators would otherwise put the binary in a per config subfolder
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
 
 foreach(CONFIG ${CMAKE_CONFIGURATION_TYPES})
     string(TOUPPER "${CONFIG}" CONFIG_UPPER)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${CONFIG_UPPER} "${CMAKE_BINARY_DIR}")
 endforeach()
+
+# the pdfium build to link against, which decides the directory and the runtime
+set(PDFIUM_CONFIG "release" CACHE STRING "pdfium build configuration")
 
 # platform
 if(APPLE)
@@ -22,11 +24,12 @@ else()
     set(PDFIUM_PLATFORM "linux")
 endif()
 
-set(PDFIUM_INCLUDE_DIR "../build/${PDFIUM_PLATFORM}/release/include")
+set(PDFIUM_DIR "../build/${PDFIUM_PLATFORM}/${PDFIUM_CONFIG}")
+set(PDFIUM_INCLUDE_DIR "${PDFIUM_DIR}/include")
 
 # macos ships a single universal library, the other platforms keep one directory per arch
 if(APPLE)
-    set(PDFIUM_LIB_DIR "../build/${PDFIUM_PLATFORM}/release/lib")
+    set(PDFIUM_LIB_DIR "${PDFIUM_DIR}/lib")
 else()
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)$")
         set(PDFIUM_ARCH "arm64")
@@ -34,7 +37,7 @@ else()
         set(PDFIUM_ARCH "x64")
     endif()
 
-    set(PDFIUM_LIB_DIR "../build/${PDFIUM_PLATFORM}/release/lib/${PDFIUM_ARCH}")
+    set(PDFIUM_LIB_DIR "${PDFIUM_DIR}/lib/${PDFIUM_ARCH}")
 endif()
 
 # sources
@@ -62,10 +65,16 @@ if(APPLE)
     target_link_libraries(${PROJECT_NAME} PRIVATE ${FWK_CORE_GRAPHICS})
     target_link_libraries(${PROJECT_NAME} PRIVATE ${FWK_SECURITY})
 elseif(WIN32)
-    # pdfium is built with the static release crt, so anything linking against it
-    # has to use the same one or the link fails on duplicated runtime symbols.
-    # the system libraries it needs are already in the msvc defaults cmake links
-    set_property(TARGET ${PROJECT_NAME} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded")
+    # pdfium is built with the static crt, so anything linking against it has to
+    # use the same one or the link fails on duplicated runtime symbols. the system
+    # libraries it needs are already in the msvc defaults cmake links
+    if(PDFIUM_CONFIG STREQUAL "debug")
+        set(PDFIUM_MSVC_RUNTIME "MultiThreadedDebug")
+    else()
+        set(PDFIUM_MSVC_RUNTIME "MultiThreaded")
+    endif()
+
+    set_property(TARGET ${PROJECT_NAME} PROPERTY MSVC_RUNTIME_LIBRARY "${PDFIUM_MSVC_RUNTIME}")
 else()
     find_package(Threads REQUIRED)
 

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -4,7 +4,7 @@ project(sample)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# multi config generators would otherwise put the binary in a per config subfolder
+# Multi config generators would otherwise put the binary in a per config subfolder.
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
 
 foreach(CONFIG ${CMAKE_CONFIGURATION_TYPES})
@@ -12,7 +12,7 @@ foreach(CONFIG ${CMAKE_CONFIGURATION_TYPES})
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${CONFIG_UPPER} "${CMAKE_BINARY_DIR}")
 endforeach()
 
-# the pdfium build to link against, which decides the directory and the runtime
+# The pdfium build to link against, which decides the library directory and the runtime.
 set(PDFIUM_CONFIG "release" CACHE STRING "pdfium build configuration")
 
 # platform
@@ -27,7 +27,7 @@ endif()
 set(PDFIUM_DIR "../build/${PDFIUM_PLATFORM}/${PDFIUM_CONFIG}")
 set(PDFIUM_INCLUDE_DIR "${PDFIUM_DIR}/include")
 
-# macos ships a single universal library, the other platforms keep one directory per arch
+# macOS ships a single universal library, while the other platforms keep one directory per architecture.
 if(APPLE)
     set(PDFIUM_LIB_DIR "${PDFIUM_DIR}/lib")
 else()
@@ -65,9 +65,8 @@ if(APPLE)
     target_link_libraries(${PROJECT_NAME} PRIVATE ${FWK_CORE_GRAPHICS})
     target_link_libraries(${PROJECT_NAME} PRIVATE ${FWK_SECURITY})
 elseif(WIN32)
-    # pdfium is built with the static crt, so anything linking against it has to
-    # use the same one or the link fails on duplicated runtime symbols. the system
-    # libraries it needs are already in the msvc defaults cmake links
+    # Linking against pdfium requires the same static runtime it was built with, or the link fails on duplicated symbols.
+    # The system libraries it needs are already in the msvc defaults cmake links.
     if(PDFIUM_CONFIG STREQUAL "debug")
         set(PDFIUM_MSVC_RUNTIME "MultiThreadedDebug")
     else()

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -4,6 +4,15 @@ project(sample)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# multi config generators put the binary under a per configuration directory,
+# so pin the output and every platform finds it in the same place
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+
+foreach(CONFIG ${CMAKE_CONFIGURATION_TYPES})
+    string(TOUPPER "${CONFIG}" CONFIG_UPPER)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${CONFIG_UPPER} "${CMAKE_BINARY_DIR}")
+endforeach()
+
 # platform
 if(APPLE)
     set(PDFIUM_PLATFORM "macos")

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -1,9 +1,36 @@
 cmake_minimum_required(VERSION 3.24)
 project(sample)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# platform
+if(APPLE)
+    set(PDFIUM_PLATFORM "macos")
+elseif(WIN32)
+    set(PDFIUM_PLATFORM "windows")
+else()
+    set(PDFIUM_PLATFORM "linux")
+endif()
+
+set(PDFIUM_INCLUDE_DIR "../build/${PDFIUM_PLATFORM}/release/include")
+
+# macos ships a single universal library, the other platforms keep one directory per arch
+if(APPLE)
+    set(PDFIUM_LIB_DIR "../build/${PDFIUM_PLATFORM}/release/lib")
+else()
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)$")
+        set(PDFIUM_ARCH "arm64")
+    else()
+        set(PDFIUM_ARCH "x64")
+    endif()
+
+    set(PDFIUM_LIB_DIR "../build/${PDFIUM_PLATFORM}/release/lib/${PDFIUM_ARCH}")
+endif()
+
 # sources
 file(GLOB S_FILES_PROJECT "src/*.cpp")
-file(GLOB H_FILES_PDFIUM "../build/macos/release/include/*.h")
+file(GLOB H_FILES_PDFIUM "${PDFIUM_INCLUDE_DIR}/*.h")
 
 set(
     PROJ_FILES
@@ -11,21 +38,32 @@ set(
     ${H_FILES_PDFIUM}
 )
 
-# frameworks
-find_library(FWK_CORE_GRAPHICS CoreGraphics)
-find_library(FWK_FOUNDATION Foundation)
-find_library(FWK_SECURITY Security)
-
 # target
 add_executable(${PROJECT_NAME} ${PROJ_FILES})
 
 # links
 target_link_libraries(${PROJECT_NAME} PRIVATE "pdfium")
 
-target_link_libraries(${PROJECT_NAME} PRIVATE ${FWK_FOUNDATION})
-target_link_libraries(${PROJECT_NAME} PRIVATE ${FWK_CORE_GRAPHICS})
-target_link_libraries(${PROJECT_NAME} PRIVATE ${FWK_SECURITY})
+if(APPLE)
+    find_library(FWK_CORE_GRAPHICS CoreGraphics)
+    find_library(FWK_FOUNDATION Foundation)
+    find_library(FWK_SECURITY Security)
+
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${FWK_FOUNDATION})
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${FWK_CORE_GRAPHICS})
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${FWK_SECURITY})
+elseif(WIN32)
+    # pdfium is built with the static release crt, so anything linking against it
+    # has to use the same one or the link fails on duplicated runtime symbols.
+    # the system libraries it needs are already in the msvc defaults cmake links
+    set_property(TARGET ${PROJECT_NAME} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded")
+else()
+    find_package(Threads REQUIRED)
+
+    target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads)
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
+endif()
 
 # paths
-target_link_directories(${PROJECT_NAME} PRIVATE "../build/macos/release/lib")
-target_include_directories(${PROJECT_NAME} PRIVATE "../build/macos/release/include")
+target_link_directories(${PROJECT_NAME} PRIVATE ${PDFIUM_LIB_DIR})
+target_include_directories(${PROJECT_NAME} PRIVATE ${PDFIUM_INCLUDE_DIR})

--- a/sample/src/main.cpp
+++ b/sample/src/main.cpp
@@ -83,7 +83,7 @@ int main(int argc, char **argv)
         // render page
         FPDF_PAGE page = FPDF_LoadPage(doc, 0);
 
-        // a heap buffer, since variable length arrays are not standard c++
+        // A heap buffer, since variable length arrays are not standard C++.
         std::vector<uint8_t> buffer((size_t)pageWidth * (size_t)pageHeight * 4);
 
         FPDF_BITMAP createdpages = FPDFBitmap_CreateEx((int)pageWidth, (int)pageHeight, FPDFBitmap_BGRx, buffer.data(), (int)pageWidth * 4);

--- a/sample/src/main.cpp
+++ b/sample/src/main.cpp
@@ -7,8 +7,6 @@
 
 int main(int argc, char **argv)
 {
-    // Adapted from https://github.com/lukas-w/pdfium/blob/master/docs/getting-started.md.
-
     std::cout << "Starting..." << std::endl;
 
     FPDF_LIBRARY_CONFIG config;

--- a/sample/src/main.cpp
+++ b/sample/src/main.cpp
@@ -7,7 +7,7 @@
 
 int main(int argc, char **argv)
 {
-    // sample: https://github.com/lukas-w/pdfium/blob/master/docs/getting-started.md
+    // Adapted from https://github.com/lukas-w/pdfium/blob/master/docs/getting-started.md.
 
     std::cout << "Starting..." << std::endl;
 
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
 
     if (pageCount > 0)
     {
-        // page size
+        // Reads the size of the first page.
         double_t pageWidth;
         double_t pageHeight;
 
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
 
         std::cout << "First page has size: " << floor(pageWidth * 0.0352778) << "cm X " << floor(pageHeight * 0.0352778) << "cm" << std::endl;
 
-        // render page
+        // Renders the first page.
         FPDF_PAGE page = FPDF_LoadPage(doc, 0);
 
         // A heap buffer, since variable length arrays are not standard C++.

--- a/sample/src/main.cpp
+++ b/sample/src/main.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
 #include <cmath>
+#include <cstdint>
+#include <vector>
 
 #include "fpdfview.h"
 
@@ -15,6 +17,7 @@ int main(int argc, char **argv)
     config.m_pIsolate = nullptr;
     config.m_v8EmbedderSlot = 0;
     config.m_pPlatform = nullptr;
+    config.m_RendererType = FPDF_RENDERERTYPE_AGG;
 
     FPDF_InitLibraryWithConfig(&config);
 
@@ -80,16 +83,17 @@ int main(int argc, char **argv)
         // render page
         FPDF_PAGE page = FPDF_LoadPage(doc, 0);
 
-        uint8_t buffer[(int)pageWidth * (int)pageHeight * 4];
+        // a heap buffer, since variable length arrays are not standard c++
+        std::vector<uint8_t> buffer((size_t)pageWidth * (size_t)pageHeight * 4);
 
-        FPDF_BITMAP createdpages = FPDFBitmap_CreateEx((int)pageWidth, (int)pageHeight, FPDFBitmap_BGRx, buffer, (int)pageWidth * 4);
-        uint background = 0xFFFFFFFF;
+        FPDF_BITMAP createdpages = FPDFBitmap_CreateEx((int)pageWidth, (int)pageHeight, FPDFBitmap_BGRx, buffer.data(), (int)pageWidth * 4);
+        uint32_t background = 0xFFFFFFFF;
         FPDFBitmap_FillRect(createdpages, 0, 0, (int)pageWidth, (int)pageHeight, background);
         FPDF_RenderPageBitmap(createdpages, page, 0, 0, (int)pageWidth, (int)pageHeight, 0, FPDF_ANNOT);
         FPDFBitmap_Destroy(createdpages);
         FPDF_ClosePage(page);
 
-        std::cout << "Buffer size: " << (sizeof(buffer) / sizeof((buffer)[0])) << std::endl;
+        std::cout << "Buffer size: " << buffer.size() << std::endl;
     }
 
     FPDF_CloseDocument(doc);


### PR DESCRIPTION
Both are already supported by pdfium, so this follows the macos layout: a module per platform with the same six tasks, target lists in config.py, a workflow that builds and publishes the archive, and a build tutorial.

Both produce a static library against the system C++ runtime, and since neither has a fat binary format the libraries are installed one directory per architecture. Only x64 is enabled, adding another one is a line in config.py.

The sample only ever built on macos, so it now picks the include and library paths per platform and links what each one needs. Two things in it were fatal outside clang: a variable length array, which is not standard C++, and the non standard uint type. The library config also declared version 3 while leaving m_RendererType uninitialized.